### PR TITLE
Support grouping by multiple fields with `@indexBy` directive

### DIFF
--- a/src/DirectiveProcessor.php
+++ b/src/DirectiveProcessor.php
@@ -14,7 +14,7 @@ final class DirectiveProcessor
      * Extract the @indexBy directive field path
      *
      * @param NodeList<DirectiveNode> $directives
-     * @return list<string>
+     * @return list<list<string>>
      */
     public function getIndexByDirective(NodeList $directives) : array
     {
@@ -27,7 +27,18 @@ final class DirectiveProcessor
                 continue;
             }
 
-            return explode('.', $directive->arguments[0]->value->value);
+            $value = $directive->arguments[0]->value->value;
+
+            // Split by comma for multi-field indexing
+            $fields = explode(',', $value);
+            $result = [];
+
+            foreach ($fields as $field) {
+                $field = trim($field);
+                $result[] = explode('.', $field);
+            }
+
+            return $result;
         }
 
         return [];

--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -23,6 +23,7 @@ use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\BackedEnumTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\CollectionTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer\IndexByCollectionTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\NullableTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\ObjectTypeInitializer;
 
@@ -42,6 +43,7 @@ final class PlanExecutor
         // Initialize type initializer
         $typeInitializer = new DelegatingTypeInitializer(
             new NullableTypeInitializer(),
+            new IndexByCollectionTypeInitializer(),
             new CollectionTypeInitializer(),
             new BackedEnumTypeInitializer($config->addUnknownCaseToEnums, $config->namespace),
             new ObjectTypeInitializer(),

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -378,9 +378,6 @@ final class Planner
                 $this->config->outputDir . '/Fragment/' . $name,
                 $fqcn,
                 'fragment',
-                nullable: null,
-                indexByType: null,
-                indexBy: [],
                 isGeneratingTopLevelFragment: true,
             );
 

--- a/src/Planner/PlanningContext.php
+++ b/src/Planner/PlanningContext.php
@@ -12,13 +12,14 @@ use Symfony\Component\TypeInfo\Type as SymfonyType;
 final readonly class PlanningContext
 {
     /**
-     * @param list<string> $indexBy
+     * @param null|list<SymfonyType> $indexByType
+     * @param list<list<string>> $indexBy
      */
     public function __construct(
         public string $outputDirectory,
         public string $fqcn,
         public string $path,
-        public ?SymfonyType $indexByType = null,
+        public ?array $indexByType = null,
         public array $indexBy = [],
         public bool $isGeneratingTopLevelFragment = false,
         public bool $isInsideFragmentContext = false,
@@ -51,9 +52,10 @@ final readonly class PlanningContext
     }
 
     /**
-     * @param list<string> $indexBy
+     * @param null|list<SymfonyType> $indexByType
+     * @param list<list<string>> $indexBy
      */
-    public function withIndexBy(?SymfonyType $indexByType, array $indexBy) : self
+    public function withIndexBy(?array $indexByType, array $indexBy) : self
     {
         return new self(
             $this->outputDirectory,

--- a/src/TypeInitializer/IndexByCollectionTypeInitializer.php
+++ b/src/TypeInitializer/IndexByCollectionTypeInitializer.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\TypeInitializer;
+
+use Generator;
+use Override;
+use Ruudk\CodeGenerator\CodeGenerator;
+use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * @phpstan-import-type CodeLine from CodeGenerator
+ * @implements TypeInitializer<IndexByCollectionType>
+ */
+final class IndexByCollectionTypeInitializer implements TypeInitializer
+{
+    #[Override]
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof IndexByCollectionType;
+    }
+
+    /**
+     * @return Generator<CodeLine>
+     */
+    #[Override]
+    public function initialize(
+        Type $type,
+        CodeGenerator $generator,
+        string $variable,
+        DelegatingTypeInitializer $delegator,
+    ) : Generator {
+        // Check if this is multi-field indexing (nested IndexByCollectionType)
+        if ($type->value instanceof IndexByCollectionType) {
+            // Multi-field indexing: use closure with foreach to handle duplicates
+            yield '(function() {';
+            yield $generator->indent(function () use ($generator, $type, $variable, $delegator) {
+                $nestedType = $type->value;
+
+                yield '$result = [];';
+                yield sprintf('foreach (%s as $item) {', $variable);
+
+                yield $generator->indent(function () use ($generator, $type, $delegator, $nestedType) {
+                    yield from $generator->wrap(
+                        sprintf(
+                            '$result[$item%s][$item%s] = ',
+                            $this->buildKeyAccess($type->indexBy),
+                            $this->buildKeyAccess($nestedType->indexBy),
+                        ),
+                        $delegator($nestedType->value, $generator, '$item'),
+                        ';',
+                    );
+                });
+                yield '}';
+
+                yield '';
+                yield 'return $result;';
+            });
+            yield '})()';
+
+            return;
+        }
+
+        // Single-field indexing: use array_combine
+        yield 'array_combine(';
+        yield $generator->indent(function () use ($generator, $type, $variable, $delegator) {
+            if (count($type->indexBy) > 1) {
+                yield sprintf(
+                    'array_map(fn($item) => $item%s, %s),',
+                    $this->buildKeyAccess($type->indexBy),
+                    $variable,
+                );
+            } else {
+                yield sprintf(
+                    'array_column(%s, %s),',
+                    $variable,
+                    var_export($type->indexBy[0], true),
+                );
+            }
+
+            yield from $generator->wrap(
+                'array_map(fn($item) => ',
+                $delegator($type->value, $generator, '$item'),
+                sprintf(', %s),', $variable),
+            );
+        });
+        yield ')';
+    }
+
+    /**
+     * @param list<string> $indexBy
+     */
+    private function buildKeyAccess(array $indexBy) : string
+    {
+        return join(array_map(
+            fn($key) => sprintf('[%s]', var_export($key, true)),
+            $indexBy,
+        ));
+    }
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField;
+
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection;
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\Issu;
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public CustomerConnection $customers {
+        get => $this->customers ??= new CustomerConnection($this->data['customers']);
+    }
+
+    /**
+     * @var array<int,Issu>
+     */
+    public array $issues {
+        get => $this->issues ??= array_combine(
+            array_column($this->data['issues'], 'id'),
+            array_map(fn($item) => new Issu($item), $this->data['issues']),
+        );
+    }
+
+    /**
+     * @var array<string,array<string,Project>>
+     */
+    public array $projects {
+        get => $this->projects ??= (function() {
+            $result = [];
+            foreach ($this->data['projects'] as $item) {
+                $result[$item['id']][$item['name']] = new Project($item);
+            }
+
+            return $result;
+        })();
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'customers': array{
+     *         'edges': list<array{
+     *             'node': array{
+     *                 'id': int,
+     *                 'name': string,
+     *             },
+     *         }>,
+     *     },
+     *     'issues': list<array{
+     *         'id': int,
+     *         'name': string,
+     *     }>,
+     *     'projects': list<array{
+     *         'id': string,
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data;
+
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection\CustomerEdge;
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection\CustomerEdge\Customer;
+
+// This file was automatically generated and should not be edited.
+
+final class CustomerConnection
+{
+    /**
+     * @var array<int,array<string,CustomerEdge>>
+     */
+    public array $edges {
+        get => $this->edges ??= (function() {
+            $result = [];
+            foreach ($this->data['edges'] as $item) {
+                $result[$item['node']['id']][$item['node']['name']] = new CustomerEdge($item);
+            }
+
+            return $result;
+        })();
+    }
+
+    /**
+     * @var list<Customer>
+     */
+    public array $nodes {
+        get {
+            $nodes = [];
+            foreach ($this->edges as $edgeGroup) {
+                foreach ($edgeGroup as $edge) {
+                    $nodes[] = $edge->node;
+                }
+            }
+
+            return $nodes;
+        }
+    }
+
+    /**
+     * @param array{
+     *     'edges': list<array{
+     *         'node': array{
+     *             'id': int,
+     *             'name': string,
+     *         },
+     *     }>,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection;
+
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection\CustomerEdge\Customer;
+
+// This file was automatically generated and should not be edited.
+
+final class CustomerEdge
+{
+    public Customer $node {
+        get => $this->node ??= new Customer($this->data['node']);
+    }
+
+    /**
+     * @param array{
+     *     'node': array{
+     *         'id': int,
+     *         'name': string,
+     *     },
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge/Customer.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge/Customer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data\CustomerConnection\CustomerEdge;
+
+// This file was automatically generated and should not be edited.
+
+final class Customer
+{
+    public int $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'id': int,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Issu.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Issu.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class Issu
+{
+    public int $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'id': int,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Project.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Project.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+    public string $code;
+
+    /**
+     * @param array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+        $this->code = $error['code'];
+    }
+}

--- a/tests/IndexByDirective/Generated/Query/TestMultiFieldQuery.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiFieldQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query;
+
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\Data;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+// Based on tests/IndexByDirective/TestMultiField.graphql
+
+final readonly class TestMultiFieldQuery {
+    public const string OPERATION_NAME = 'TestMultiField';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query TestMultiField {
+          projects {
+            id
+            name
+          }
+          issues {
+            id
+            name
+          }
+          customers {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/IndexByDirective/IndexByDirectiveTest.php
+++ b/tests/IndexByDirective/IndexByDirectiveTest.php
@@ -6,7 +6,9 @@ namespace Ruudk\GraphQLCodeGenerator\IndexByDirective;
 
 use Override;
 use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLRequestMatcher;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiFieldQuery;
 use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestQuery;
 use Symfony\Component\TypeInfo\Type;
 
@@ -91,5 +93,85 @@ final class IndexByDirectiveTest extends GraphQLTestCase
         self::assertSame('Customer 100', $result->customers->nodes[100]->name);
         self::assertArrayHasKey(200, $result->customers->nodes);
         self::assertSame('Customer 200', $result->customers->nodes[200]->name);
+    }
+
+    public function testMultiFieldIndexBy() : void
+    {
+        $result = new TestMultiFieldQuery($this->getClient([
+            'data' => [
+                'projects' => [
+                    [
+                        'id' => '16b6f807-689d-4d3f-9c9b-a1c774eed7ea',
+                        'name' => 'GraphQL Code Generator',
+                    ],
+                    [
+                        'id' => '644e7023-6e09-4e18-9ef2-947de0d0ed82',
+                        'name' => 'GraphQL PHP',
+                    ],
+                    [
+                        'id' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
+                        'name' => 'GraphQL Code Generator',
+                    ],
+                ],
+                'issues' => [
+                    [
+                        'id' => 222,
+                        'name' => 'Issue 222',
+                    ],
+                    [
+                        'id' => 444,
+                        'name' => 'Issue 444',
+                    ],
+                ],
+                'customers' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'id' => 100,
+                                'name' => 'Customer Alpha',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'id' => 200,
+                                'name' => 'Customer Beta',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'id' => 100,
+                                'name' => 'Customer Gamma',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], new GraphQLRequestMatcher(operationName: 'TestMultiField')))->execute();
+
+        // Test multi-field indexing: projects indexed by id,name should create nested arrays
+        self::assertCount(3, $result->projects);
+        self::assertArrayHasKey('16b6f807-689d-4d3f-9c9b-a1c774eed7ea', $result->projects);
+        self::assertArrayHasKey('GraphQL Code Generator', $result->projects['16b6f807-689d-4d3f-9c9b-a1c774eed7ea']);
+        self::assertSame('GraphQL Code Generator', $result->projects['16b6f807-689d-4d3f-9c9b-a1c774eed7ea']['GraphQL Code Generator']->name);
+
+        self::assertArrayHasKey('644e7023-6e09-4e18-9ef2-947de0d0ed82', $result->projects);
+        self::assertArrayHasKey('GraphQL PHP', $result->projects['644e7023-6e09-4e18-9ef2-947de0d0ed82']);
+        self::assertSame('GraphQL PHP', $result->projects['644e7023-6e09-4e18-9ef2-947de0d0ed82']['GraphQL PHP']->name);
+
+        self::assertArrayHasKey('a1b2c3d4-e5f6-7890-1234-567890abcdef', $result->projects);
+        self::assertArrayHasKey('GraphQL Code Generator', $result->projects['a1b2c3d4-e5f6-7890-1234-567890abcdef']);
+        self::assertSame('GraphQL Code Generator', $result->projects['a1b2c3d4-e5f6-7890-1234-567890abcdef']['GraphQL Code Generator']->name);
+
+        // Test multi-field indexing on edges: edges indexed by node.id,node.name
+        self::assertCount(2, $result->customers->edges);
+        self::assertArrayHasKey(100, $result->customers->edges);
+        self::assertArrayHasKey('Customer Alpha', $result->customers->edges[100]);
+        self::assertSame('Customer Alpha', $result->customers->edges[100]['Customer Alpha']->node->name);
+        self::assertArrayHasKey('Customer Gamma', $result->customers->edges[100]);
+        self::assertSame('Customer Gamma', $result->customers->edges[100]['Customer Gamma']->node->name);
+
+        self::assertArrayHasKey(200, $result->customers->edges);
+        self::assertArrayHasKey('Customer Beta', $result->customers->edges[200]);
+        self::assertSame('Customer Beta', $result->customers->edges[200]['Customer Beta']->node->name);
     }
 }

--- a/tests/IndexByDirective/TestMultiField.graphql
+++ b/tests/IndexByDirective/TestMultiField.graphql
@@ -1,0 +1,18 @@
+query TestMultiField {
+    projects @indexBy(field: "id,name") {
+        id
+        name
+    }
+    issues @indexBy(field: "id") {
+        id
+        name
+    }
+    customers {
+        edges @indexBy(field: "node.id,node.name") {
+            node {
+                id
+                name
+            }
+        }
+    }
+}

--- a/tests/Validator/IndexByValidatorTest.php
+++ b/tests/Validator/IndexByValidatorTest.php
@@ -1,0 +1,637 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Validator;
+
+use GraphQL\Error\Error;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Validator\DocumentValidator;
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type as SymfonyType;
+
+final class IndexByValidatorTest extends TestCase
+{
+    private Schema $schema;
+    private IndexByValidator $validator;
+
+    #[Override]
+    protected function setUp() : void
+    {
+        // Create a test schema
+        $statusEnum = new EnumType([
+            'name' => 'UserStatus',
+            'values' => [
+                'ACTIVE' => [
+                    'value' => 'active',
+                ],
+                'INACTIVE' => [
+                    'value' => 'inactive',
+                ],
+                'PENDING' => [
+                    'value' => 'pending',
+                ],
+            ],
+        ]);
+
+        $userType = new ObjectType([
+            'name' => 'User',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'name' => Type::nonNull(Type::string()),
+                'email' => Type::string(), // nullable string
+                'age' => Type::int(), // nullable int
+                'score' => Type::float(), // nullable float
+                'active' => Type::boolean(), // nullable boolean
+                'rating' => Type::nonNull(Type::float()), // non-null float - invalid for indexing
+                'verified' => Type::nonNull(Type::boolean()), // non-null boolean - invalid for indexing
+                'status' => Type::nonNull($statusEnum), // non-null enum - valid for indexing
+                'optionalStatus' => $statusEnum, // nullable enum
+            ],
+        ]);
+
+        $edgeType = new ObjectType([
+            'name' => 'UserEdge',
+            'fields' => [
+                'node' => Type::nonNull($userType),
+                'cursor' => Type::string(),
+            ],
+        ]);
+
+        $connectionType = new ObjectType([
+            'name' => 'UserConnection',
+            'fields' => [
+                'edges' => Type::listOf($edgeType),
+            ],
+        ]);
+
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'users' => [
+                    'type' => Type::listOf($userType),
+                    'resolve' => fn() => [],
+                ],
+                'userConnection' => [
+                    'type' => $connectionType,
+                    'resolve' => fn() => [],
+                ],
+            ],
+        ]);
+
+        $this->schema = new Schema([
+            'query' => $queryType,
+        ]);
+
+        // Set up the validator with scalar mappings
+        $this->validator = new IndexByValidator([
+            'ID' => SymfonyType::string(),
+            'String' => SymfonyType::string(),
+            'Int' => SymfonyType::int(),
+            'Float' => SymfonyType::float(),
+            'Boolean' => SymfonyType::bool(),
+        ]);
+    }
+
+    public function testValidSingleFieldIndexBy() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id") {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidSingleFieldIndexByWithStringField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "name") {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidNestedFieldIndexBy() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                userConnection {
+                    edges @indexBy(field: "node.id") {
+                        node {
+                            id
+                            name
+                        }
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidMultiFieldIndexBy() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,name") {
+                    id
+                    name
+                    email
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidMultiFieldIndexByWithSpaces() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id, name") {
+                    id
+                    name
+                    email
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidMultiFieldNestedIndexBy() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                userConnection {
+                    edges @indexBy(field: "node.id,node.name") {
+                        node {
+                            id
+                            name
+                        }
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testInvalidIndexByOnNonList() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                userConnection @indexBy(field: "edges") {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('@indexBy can only be used on lists', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByFieldNotSelected() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "name") {
+                    id
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "name" is not selected in the indexBy directive', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByFieldDoesNotExist() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "nonexistent") {
+                    id
+                    name
+                    nonexistent
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertGreaterThanOrEqual(1, count($errors));
+        self::assertStringContainsString('Field "nonexistent" is not defined for type', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNullableFloatField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "score") {
+                    id
+                    score
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "score" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNonNullFloatField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "rating") {
+                    id
+                    rating
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('@indexBy(field: "rating") cannot be used because the field is not a valid array key type', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNullableBooleanField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "active") {
+                    id
+                    active
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "active" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNonNullBooleanField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "verified") {
+                    id
+                    verified
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('@indexBy(field: "verified") cannot be used because the field is not a valid array key type', $errors[0]->getMessage());
+    }
+
+    public function testMultiFieldIndexByWithOneInvalidField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,score") {
+                    id
+                    score
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "score" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testMultiFieldIndexByWithOneFieldNotSelected() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,name") {
+                    id
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "name" is not selected in the indexBy directive', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNullableStringField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "email") {
+                    id
+                    email
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "email" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testInvalidIndexByWithNullableIntField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "age") {
+                    id
+                    age
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "age" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testValidIndexByWithNonNullEnumField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "status") {
+                    id
+                    status
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testInvalidIndexByWithNullableEnumField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "optionalStatus") {
+                    id
+                    optionalStatus
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "optionalStatus" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testMultiFieldIndexByWithMixedNullability() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,email") {
+                    id
+                    email
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "email" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    public function testValidMultiFieldIndexByWithNonNullFields() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,name,status") {
+                    id
+                    name
+                    status
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testIndexByWithEmptyField() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "") {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Empty field in @indexBy directive', $errors[0]->getMessage());
+    }
+
+    public function testMultiFieldIndexByWithEmptyFieldInMiddle() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(field: "id,,name") {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        // Two errors: one for each empty field, one for name not selected
+        self::assertGreaterThanOrEqual(1, count($errors));
+        self::assertStringContainsString('Empty field in @indexBy directive', $errors[0]->getMessage());
+    }
+
+    public function testIndexByWithoutFieldArgument() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        // Without field argument, the validator should skip
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testIndexByWithWrongArgumentName() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                users @indexBy(value: "id") {
+                    id
+                    name
+                }
+            }
+            GRAPHQL;
+
+        // With wrong argument name, the validator should skip
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testIndexByOnNullableList() : void
+    {
+        $query = <<<'GRAPHQL'
+            query {
+                userConnection {
+                    edges @indexBy(field: "node.id") {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $errors = $this->validate($query);
+        self::assertCount(0, $errors);
+    }
+
+    public function testNestedIndexByWithDeepPath() : void
+    {
+        // Create a more complex schema for this test
+        $addressType = new ObjectType([
+            'name' => 'Address',
+            'fields' => [
+                'id' => Type::nonNull(Type::string()),
+                'street' => Type::string(),
+                'zipCode' => Type::nonNull(Type::string()),
+            ],
+        ]);
+
+        $userWithAddressType = new ObjectType([
+            'name' => 'UserWithAddress',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'address' => Type::nonNull($addressType),
+                'optionalAddress' => $addressType, // nullable
+            ],
+        ]);
+
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'usersWithAddress' => [
+                    'type' => Type::listOf($userWithAddressType),
+                    'resolve' => fn() => [],
+                ],
+            ],
+        ]);
+
+        $schema = new Schema([
+            'query' => $queryType,
+        ]);
+
+        $query = <<<'GRAPHQL'
+            query {
+                usersWithAddress @indexBy(field: "address.id") {
+                    id
+                    address {
+                        id
+                        street
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $document = Parser::parse($query);
+        $errors = DocumentValidator::validate($schema, $document, [$this->validator]);
+        self::assertCount(0, $errors);
+    }
+
+    public function testInvalidIndexByWithNullableIntermediateField() : void
+    {
+        // Create a schema with nullable intermediate field
+        $addressType = new ObjectType([
+            'name' => 'Address',
+            'fields' => [
+                'id' => Type::nonNull(Type::string()),
+                'street' => Type::string(),
+            ],
+        ]);
+
+        $userWithAddressType = new ObjectType([
+            'name' => 'UserWithAddress',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'optionalAddress' => $addressType, // nullable intermediate field
+            ],
+        ]);
+
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'usersWithAddress' => [
+                    'type' => Type::listOf($userWithAddressType),
+                    'resolve' => fn() => [],
+                ],
+            ],
+        ]);
+
+        $schema = new Schema([
+            'query' => $queryType,
+        ]);
+
+        $query = <<<'GRAPHQL'
+            query {
+                usersWithAddress @indexBy(field: "optionalAddress.id") {
+                    id
+                    optionalAddress {
+                        id
+                    }
+                }
+            }
+            GRAPHQL;
+
+        $document = Parser::parse($query);
+        $errors = DocumentValidator::validate($schema, $document, [$this->validator]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('Field "optionalAddress" is nullable and cannot be used for @indexBy', $errors[0]->getMessage());
+    }
+
+    /**
+     * @return array<Error>
+     */
+    private function validate(string $query) : array
+    {
+        $document = Parser::parse($query);
+
+        return DocumentValidator::validate($this->schema, $document, [$this->validator]);
+    }
+}


### PR DESCRIPTION
```graphql
{
   customers {
        edges @indexBy(field: "node.id,node.name") {
            node {
                id
                name
            }
        }
    }
}
```

Generates the following code:
```php
/**
 * @var array<int,array<string,CustomerEdge>>
 */
public array $edges {
    get => $this->edges ??= (function() {
        $result = [];
        foreach ($this->data['edges'] as $item) {
            $result[$item['node']['id']][$item['node']['name']] = new CustomerEdge($item);
        }
        return $result;
    })();
}
```
