### PR TITLE
Introduce IndexByDirectiveSchemaExtender

### DIFF
--- a/src/GraphQL/IndexByDirectiveSchemaExtender.php
+++ b/src/GraphQL/IndexByDirectiveSchemaExtender.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\SchemaExtender;
+use InvalidArgumentException;
+use JsonException;
+use Webmozart\Assert\Assert;
+
+final readonly class IndexByDirectiveSchemaExtender
+{
+    /**
+     * Extends schema with @indexBy directive. If @indexBy already exists, it verifies that it's correct.
+     *
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     * @throws InvariantViolation
+     * @throws Exception
+     */
+    public static function extend(Schema $schema) : Schema
+    {
+        $existing = $schema->getDirective('indexBy');
+
+        if ($existing !== null) {
+            Assert::eq($existing->locations, ['FIELD'], 'Expected @indexBy to be on FIELD');
+            Assert::count($existing->args, 1, 'Expected @indexBy to have 1 argument');
+
+            [$field] = $existing->args;
+            Assert::eq($field->name, 'field', 'Expected @indexBy argument to be named "field"');
+            Assert::eq(Type::nonNull(Type::string()), $field->getType(), 'Expected @indexBy argument to be a non-null string');
+
+            return $schema;
+        }
+
+        return SchemaExtender::extend(
+            $schema,
+            Parser::parse(
+                <<<'GRAPHQL'
+                    directive @indexBy(field: String!) on FIELD
+                    GRAPHQL,
+            ),
+        );
+    }
+}

--- a/src/SchemaLoader.php
+++ b/src/SchemaLoader.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator;
 
 use Exception;
-use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildClientSchema;
 use GraphQL\Utils\BuildSchema;
-use GraphQL\Utils\SchemaExtender;
 use JsonException;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\Assert\Assert;
@@ -50,14 +48,7 @@ final class SchemaLoader
         Assert::isInstanceOf($schema, Schema::class, 'Invalid schema given, expected .graphql or .json file or Schema instance');
 
         if ($indexByDirective) {
-            $schema = SchemaExtender::extend(
-                $schema,
-                Parser::parse(
-                    <<<'GRAPHQL'
-                        directive @indexBy(field: String!) on FIELD
-                        GRAPHQL
-                ),
-            );
+            $schema = GraphQL\IndexByDirectiveSchemaExtender::extend($schema);
         }
 
         return $schema;


### PR DESCRIPTION
Extends schema with `@indexBy` directive. If `@indexBy` already exists, it verifies that it's
correct.

This can be used by clients to inject the directive in their local schema.
