### PR TITLE
Remove `code` from Error response

### DIFF
--- a/examples/Generated/Query/Search/Error.php
+++ b/examples/Generated/Query/Search/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Search;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/examples/Generated/Query/Viewer/Error.php
+++ b/examples/Generated/Query/Viewer/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Viewer;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/src/Generator/ErrorClassGenerator.php
+++ b/src/Generator/ErrorClassGenerator.php
@@ -29,12 +29,10 @@ final class ErrorClassGenerator extends AbstractGenerator
             yield '{';
             yield $generator->indent(function () use ($generator) {
                 yield 'public string $message;';
-                yield 'public string $code;';
 
                 yield '';
                 yield from $generator->docComment(sprintf('@param %s $error', $this->dumpPHPDocType(Type::arrayShape([
                     'message' => Type::string(),
-                    'code' => Type::string(),
                     'debugMessage' => [
                         'type' => Type::string(),
                         'optional' => true,
@@ -44,7 +42,6 @@ final class ErrorClassGenerator extends AbstractGenerator
                 yield '{';
                 yield $generator->indent(function () {
                     yield "\$this->message = \$error['debugMessage'] ?? \$error['message'];";
-                    yield "\$this->code = \$error['code'];";
                 });
                 yield '}';
             });

--- a/tests/ConnectionNames/Generated/Query/Test/Error.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\ConnectionNames\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/DumpDefinitions/Generated/Query/Test/Error.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\DumpDefinitions\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/DumpMethods/DumpMethodsTest.php
+++ b/tests/DumpMethods/DumpMethodsTest.php
@@ -127,7 +127,6 @@ final class DumpMethodsTest extends GraphQLTestCase
             'errors' => [
                 [
                     'message' => 'Something went wrong',
-                    'code' => 'ERROR_CODE',
                 ],
             ],
         ]))->execute();
@@ -135,6 +134,5 @@ final class DumpMethodsTest extends GraphQLTestCase
         $errors = $result->getErrors();
         self::assertCount(1, $errors);
         self::assertSame('Something went wrong', $errors[0]->message);
-        self::assertSame('ERROR_CODE', $errors[0]->code);
     }
 }

--- a/tests/DumpMethods/Generated/Query/Test/Error.php
+++ b/tests/DumpMethods/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\DumpMethods\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/DumpOrThrows/Generated/Query/Test/Error.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\DumpOrThrows\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/Enum/Generated/Query/Test/Error.php
+++ b/tests/Enum/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Enum\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Error.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\FragmentIsolation\Generated\Query\GetWorkfl
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Error.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\FragmentSpreadBug\Generated\Query\GetTransa
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/Fragments/Generated/Query/Test/Error.php
+++ b/tests/Fragments/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Fragments\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Error.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\IncludeAndSkipDirective\Generated\Query\Tes
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/IndexByDirective/Generated/Query/Test/Error.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiF
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/InlineFragments/Generated/Query/Test/Error.php
+++ b/tests/InlineFragments/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/Money/Generated/Query/ConvertMoney/Error.php
+++ b/tests/Money/Generated/Query/ConvertMoney/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Money\Generated\Query\ConvertMoney;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/NoIndexBy/Generated/Query/Test/Error.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Error.php
@@ -12,11 +12,9 @@ use Symfony\Component\DependencyInjection\Attribute\Exclude;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -24,6 +22,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/NullableConnections/Generated/Query/Test/Error.php
+++ b/tests/NullableConnections/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\NullableConnections\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/OneOfDirective/Generated/Query/Test/Error.php
+++ b/tests/OneOfDirective/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\OneOfDirective\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/Optimization/Generated/Query/Test/Error.php
+++ b/tests/Optimization/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/Simple/Generated/Query/Test/Error.php
+++ b/tests/Simple/Generated/Query/Test/Error.php
@@ -9,11 +9,9 @@ namespace Ruudk\GraphQLCodeGenerator\Simple\Generated\Query\Test;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -21,6 +19,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }

--- a/tests/SymfonyExclude/Generated/Query/Test/Error.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/Error.php
@@ -12,11 +12,9 @@ use Symfony\Component\DependencyInjection\Attribute\Exclude;
 final readonly class Error
 {
     public string $message;
-    public string $code;
 
     /**
      * @param array{
-     *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
      * } $error
@@ -24,6 +22,5 @@ final readonly class Error
     public function __construct(array $error)
     {
         $this->message = $error['debugMessage'] ?? $error['message'];
-        $this->code = $error['code'];
     }
 }


### PR DESCRIPTION
This is not part of the spec and should therefore not be done.

https://spec.graphql.org/October2021/#sec-Errors
