### PR TITLE
Do not sort arguments and input objects types

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -146,11 +146,13 @@ final class GenerateCommand
                         SchemaPrinter::doPrint(
                             $schema,
                             [
-                                'sortArguments' => true,
                                 'sortEnumValues' => true,
                                 'sortFields' => true,
-                                'sortInputFields' => true,
                                 'sortTypes' => true,
+
+                                // We might want to do this at some point automatically
+                                'sortArguments' => false,
+                                'sortInputFields' => false,
                             ],
                         ),
                     );


### PR DESCRIPTION
When updating the schema, we sort enum values, fields and types.

But we should not sort argumnets and input objects.

They should come in the order of the schema.
