### PR TITLE
Introduce inline GraphQL operations with compile-time code generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "type": "library",
     "require": {
         "php": "^8.4",
+        "nikic/php-parser": "^5.6",
+        "phpstan/phpstan": "^2.1",
         "ruudk/code-generator": "^0.4.3",
         "symfony/console": "^7.3",
         "symfony/filesystem": "^7.3",
@@ -24,7 +26,6 @@
         "php-http/message": "^1.16",
         "php-http/mock-client": "^1.6",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
@@ -61,6 +62,13 @@
             "ergebnis/composer-normalize": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true
+        }
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,124 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e14869a7fde27f8d486c5d33a76d9e00",
+    "content-hash": "9462a0532d7ab5dcde555c9e25efdcba",
     "packages": [
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-04T19:17:37+00:00"
+        },
         {
             "name": "psr/container",
             "version": "2.0.2",
@@ -3045,64 +3161,6 @@
             "time": "2025-08-06T21:43:34+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v5.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
-            },
-            "time": "2025-08-13T20:13:15+00:00"
-        },
-        {
             "name": "nikolaposa/version",
             "version": "4.2.1",
             "source": {
@@ -3989,64 +4047,6 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
             },
             "time": "2024-09-04T20:21:43+00:00"
-        },
-        {
-            "name": "phpstan/phpstan",
-            "version": "2.1.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan-shim": "*"
-            },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
-            "support": {
-                "docs": "https://phpstan.org/user-guide/getting-started",
-                "forum": "https://github.com/phpstan/phpstan/discussions",
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "security": "https://github.com/phpstan/phpstan/security/policy",
-                "source": "https://github.com/phpstan/phpstan-src"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/phpstan",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-04T19:17:37+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/examples/Generated/Query/SearchQuery.php
+++ b/examples/Generated/Query/SearchQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Search\Data;
 use Ruudk\GraphQLCodeGenerator\Examples\GitHubClient;
 
 // This file was automatically generated and should not be edited.
-// Based on Search.graphql
 
 final readonly class SearchQuery {
     public const string OPERATION_NAME = 'Search';

--- a/examples/Generated/Query/ViewerQuery.php
+++ b/examples/Generated/Query/ViewerQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Viewer\Data;
 use Ruudk\GraphQLCodeGenerator\Examples\GitHubClient;
 
 // This file was automatically generated and should not be edited.
-// Based on Viewer.graphql
 
 final readonly class ViewerQuery {
     public const string OPERATION_NAME = 'Viewer';

--- a/examples/config.php
+++ b/examples/config.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Http\Discovery\Psr18ClientDiscovery;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Examples\GitHubClient;
 use Symfony\Component\Dotenv\Dotenv;
 use Webmozart\Assert\Assert;

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,18 @@
+parametersSchema:
+    graphQLClientCodeGenerator: structure([
+        configs: listOf(string())
+    ])
+expandRelativePaths:
+    - '[parameters][graphQLClientCodeGenerator][paths][]'
+parameters:
+    graphQLClientCodeGenerator:
+        configs: []
+services:
+    -
+        class: Ruudk\GraphQLCodeGenerator\PHPStan\RestrictedUsageExtension
+        arguments:
+            configs: %graphQLClientCodeGenerator.configs%
+        tags:
+            - phpstan.restrictedClassNameUsageExtension
+            - phpstan.restrictedMethodUsageExtension
+            - phpstan.restrictedPropertyUsageExtension

--- a/phpstan.php
+++ b/phpstan.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'includes' => [
         'phar://phpstan.phar/conf/bleedingEdge.neon',
+        'extension.neon',
     ],
     'parameters' => [
         'level' => 'max',
@@ -19,6 +20,12 @@ return [
             'check' => [
                 'missingCheckedExceptionInThrows' => true,
                 'tooWideThrowType' => true,
+            ],
+        ],
+        'graphQLClientCodeGenerator' => [
+            'configs' => [
+                'examples/config.php',
+                'tests/config.php',
             ],
         ],
 

--- a/src/Attribute/GeneratedFrom.php
+++ b/src/Attribute/GeneratedFrom.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_CLASS)]
+final readonly class GeneratedFrom
+{
+    public function __construct(
+        public string $source,
+    ) {}
+}

--- a/src/Attribute/GeneratedGraphQLClient.php
+++ b/src/Attribute/GeneratedGraphQLClient.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final readonly class GeneratedGraphQLClient
+{
+    public function __construct(
+        public string $operation,
+    ) {}
+}

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Ruudk\GraphQLCodeGenerator;
+namespace Ruudk\GraphQLCodeGenerator\Config;
 
 use Closure;
 use GraphQL\Type\Schema;
 use ReflectionClass;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer;
 use Symfony\Component\TypeInfo\Type;
 
 final readonly class Config
@@ -19,6 +20,7 @@ final readonly class Config
      * @param list<string> $ignoreTypes
      * @param list<TypeInitializer\TypeInitializer> $typeInitializers
      * @param null|object|(Closure(): object) $introspectionClient
+     * @param list<string> $inlineProcessingDirectories
      */
     private function __construct(
         public Schema | string $schema,
@@ -40,10 +42,12 @@ final readonly class Config
         public bool $useEdgeNameForEdges = false,
         public bool $addNodesOnConnections = false,
         public bool $addSymfonyExcludeAttribute = false,
+        public bool $addGeneratedFromAttribute = false,
         public bool $indexByDirective = false,
         public bool $addUnknownCaseToEnums = false,
         public bool $dumpEnumIsMethods = false,
         public ?object $introspectionClient = null,
+        public array $inlineProcessingDirectories = [],
     ) {}
 
     public static function create(
@@ -94,9 +98,14 @@ final readonly class Config
         return $this->with('addNodesOnConnections', true);
     }
 
-    public function enableAddSymfonyExcludeAttribute() : self
+    public function enableSymfonyExcludeAttribute() : self
     {
         return $this->with('addSymfonyExcludeAttribute', true);
+    }
+
+    public function enableGeneratedFromAttribute() : self
+    {
+        return $this->with('addGeneratedFromAttribute', true);
     }
 
     public function enableIndexByDirective() : self
@@ -165,6 +174,11 @@ final readonly class Config
     public function withIntrospectionClient(object $client) : self
     {
         return $this->with('introspectionClient', $client);
+    }
+
+    public function withInlineProcessingDirectory(string $directory, string ...$directories) : self
+    {
+        return $this->with('inlineProcessingDirectories', [...$this->inlineProcessingDirectories, $directory, ...$directories]);
     }
 
     /**

--- a/src/Config/ConfigException.php
+++ b/src/Config/ConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Config;
+
+use Exception;
+
+final class ConfigException extends Exception {}

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Config;
+
+use Throwable;
+
+final readonly class ConfigLoader
+{
+    /**
+     * @throws ConfigException
+     * @return list<Config>
+     */
+    public static function load(string ...$paths) : array
+    {
+        $allConfigs = [];
+        foreach ($paths as $configFile) {
+            $configPath = $configFile;
+
+            if ( ! file_exists($configPath)) {
+                throw new ConfigException(sprintf('Configuration file %s does not exist', $configFile));
+            }
+
+            try {
+                $configData = require $configPath;
+            } catch (Throwable $error) {
+                throw new ConfigException(sprintf('Failed to load configuration from %s: %s', $configFile, $error->getMessage()));
+            }
+
+            if ( ! $configData instanceof Config && ! is_array($configData)) {
+                throw new ConfigException(sprintf('Failed to load configuration from %s: expected Config object or array of Config objects', $configFile));
+            }
+
+            // Add configs to our collection
+            if ($configData instanceof Config) {
+                $allConfigs[] = $configData;
+
+                continue;
+            }
+
+            // Validate array items
+            foreach ($configData as $index => $configItem) {
+                if ( ! $configItem instanceof Config) {
+                    throw new ConfigException(sprintf('Invalid configuration at index %d in %s: expected Config object', $index, $configFile));
+                }
+
+                $allConfigs[] = $configItem;
+            }
+        }
+
+        return $allConfigs;
+    }
+}

--- a/src/FragmentOrderer.php
+++ b/src/FragmentOrderer.php
@@ -5,24 +5,24 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator;
 
 use Exception;
-use GraphQL\Language\AST\DocumentNode;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use RuntimeException;
+use Ruudk\GraphQLCodeGenerator\GraphQL\DocumentNodeWithSource;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\Visitor\UsedFragmentsVisitor;
 
 final class FragmentOrderer
 {
     /**
-     * @param array<DocumentNode> $documents
+     * @param array<string, list<DocumentNodeWithSource>> $operations
      *
-     * @throws Exception
      * @throws RuntimeException
-     * @return list<FragmentDefinitionNode> Sorted so that dependencies come first
+     * @throws Exception
+     * @return list<FragmentDefinitionNodeWithSource> Sorted so that dependencies come first
      */
-    public static function orderFragments(array $documents) : array
+    public static function orderFragments(array $operations) : array
     {
         /**
-         * @var array<string, FragmentDefinitionNode> $fragments
+         * @var array<string, FragmentDefinitionNodeWithSource> $fragments
          */
         $fragments = [];
 
@@ -31,15 +31,17 @@ final class FragmentOrderer
          */
         $deps = [];
 
-        foreach ($documents as $doc) {
-            foreach ($doc->definitions as $def) {
-                if ( ! $def instanceof FragmentDefinitionNode) {
-                    continue;
-                }
+        foreach ($operations as $documents) {
+            foreach ($documents as $document) {
+                foreach ($document->definitions as $def) {
+                    if ( ! $def instanceof FragmentDefinitionNodeWithSource) {
+                        continue;
+                    }
 
-                $name = $def->name->value;
-                $fragments[$name] = $def;
-                $deps[$name] = UsedFragmentsVisitor::getUsedFragments($def);
+                    $name = $def->name->value;
+                    $fragments[$name] = $def;
+                    $deps[$name] = UsedFragmentsVisitor::getUsedFragments($def);
+                }
             }
         }
 

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\Generator;
 
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Type\ScalarType;
 use Symfony\Component\TypeInfo\Type;
 

--- a/src/Generator/InputTypeGenerator.php
+++ b/src/Generator/InputTypeGenerator.php
@@ -7,7 +7,7 @@ namespace Ruudk\GraphQLCodeGenerator\Generator;
 use JsonSerializable;
 use Override;
 use Ruudk\CodeGenerator\CodeGenerator;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\InputClassPlan;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
 use Symfony\Component\TypeInfo\Type as SymfonyType;

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -6,6 +6,7 @@ namespace Ruudk\GraphQLCodeGenerator\Generator;
 
 use JsonException;
 use Ruudk\CodeGenerator\CodeGenerator;
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\OperationClassPlan;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
@@ -17,102 +18,67 @@ final class OperationClassGenerator extends AbstractGenerator
      */
     public function generate(OperationClassPlan $plan) : string
     {
-        $operationName = $plan->operationName;
-        $operationType = $plan->operationType;
-        $queryClassName = $plan->queryClassName;
-        $operationDefinition = $plan->operationDefinition;
-        $relativeFilePath = $plan->relativeFilePath;
-
         // Extract just the types from the variables structure
         $variables = [];
         foreach ($plan->variables as $name => $variable) {
             $variables[$name] = $variable['type'];
         }
 
-        $namespace = $this->fullyQualified($operationType);
-        $className = $queryClassName . $operationType;
-        $failedException = $this->fullyQualified($operationType, $queryClassName, $queryClassName . $operationType . 'FailedException');
+        $namespace = $this->fullyQualified($plan->operationType);
+        $className = $plan->queryClassName . $plan->operationType;
+        $failedException = $this->fullyQualified(
+            $plan->operationType,
+            $plan->queryClassName,
+            $plan->queryClassName . $plan->operationType . 'FailedException',
+        );
 
         $generator = new CodeGenerator($namespace);
 
-        return $generator->dumpFile([
-            $this->dumpHeader(),
-            sprintf('// Based on %s', $relativeFilePath),
-            '',
-            sprintf('final readonly class %s {', $className),
-            $generator->indent(function () use ($failedException, $namespace, $variables, $queryClassName, $generator, $operationDefinition, $operationName) {
-                yield sprintf('public const string OPERATION_NAME = %s;', var_export($operationName, true));
-                yield sprintf('public const string OPERATION_DEFINITION = %s;', $generator->maybeNowDoc($operationDefinition, 'GRAPHQL'));
+        return $generator->dumpFile(function () use ($generator, $plan, $variables, $namespace, $failedException, $className) {
+            yield $this->dumpHeader();
 
-                yield '';
-                yield 'public function __construct(';
-                yield $generator->indent([
-                    sprintf('private %s $client,', $generator->import($this->config->client)),
-                ]);
-                yield ') {}';
+            yield '';
 
-                $parameters = $generator->indent(function () use ($generator, $variables) {
-                    foreach ($variables as $name => $phpType) {
-                        yield sprintf(
-                            '%s $%s%s,',
-                            $this->dumpPHPType($phpType, $generator->import(...)),
-                            $name,
-                            $phpType instanceof SymfonyType\NullableType ? ' = null' : '',
-                        );
-                    }
-                });
+            if ($this->config->addGeneratedFromAttribute) {
+                yield sprintf(
+                    '#[%s(source: %s)]',
+                    $generator->import(GeneratedFrom::class),
+                    str_ends_with($plan->source, '.graphql') ? var_export(
+                        $plan->source,
+                        true,
+                    ) : $generator->dumpClassReference($plan->source),
+                );
+            }
 
-                yield '';
-                yield from $generator->docComment(function () use ($generator, $variables) {
-                    foreach ($variables as $name => $phpType) {
-                        if ( ! $phpType instanceof SymfonyType\CollectionType) {
-                            continue;
-                        }
+            yield sprintf('final readonly class %s {', $className);
+            yield $generator->indent(
+                function () use ($plan, $failedException, $namespace, $variables, $generator) {
+                    yield sprintf('public const string OPERATION_NAME = %s;', var_export($plan->operationName, true));
+                    yield sprintf(
+                        'public const string OPERATION_DEFINITION = %s;',
+                        $generator->maybeNowDoc($plan->operationDefinition, 'GRAPHQL'),
+                    );
 
-                        yield sprintf(
-                            '@param %s $%s',
-                            TypeDumper::dump($phpType, $generator->import(...)),
-                            $name,
-                        );
-                    }
-                });
-
-                if ($variables !== []) {
-                    yield 'public function execute(';
-                    yield $parameters;
-                    yield sprintf(') : %s {', $generator->import(sprintf($namespace . '\\%s\Data', $queryClassName)));
-                } else {
-                    yield sprintf('public function execute() : %s', $generator->import(sprintf($namespace . '\\%s\Data', $queryClassName)));
-                    yield '{';
-                }
-
-                yield $generator->indent(function () use ($generator, $variables) {
-                    yield '$data = $this->client->graphql(';
-                    yield $generator->indent(function () use ($generator, $variables) {
-                        yield 'self::OPERATION_DEFINITION,';
-                        yield '[';
-                        yield $generator->indent(function () use ($variables) {
-                            foreach ($variables as $name => $phpType) {
-                                yield sprintf("'%s' => \$%s,", $name, $name);
-                            }
-                        });
-                        yield '],';
-                        yield 'self::OPERATION_NAME,';
-                    });
-                    yield ');';
                     yield '';
-                    yield 'return new Data(';
+                    yield 'public function __construct(';
                     yield $generator->indent([
-                        "\$data['data'] ?? [], // @phpstan-ignore argument.type",
-                        "\$data['errors'] ?? [] // @phpstan-ignore argument.type",
+                        sprintf('private %s $client,', $generator->import($this->config->client)),
                     ]);
-                    yield ');';
-                });
-                yield '}';
+                    yield ') {}';
 
-                if ($this->config->dumpOrThrows) {
+                    $parameters = $generator->indent(function () use ($generator, $variables) {
+                        foreach ($variables as $name => $phpType) {
+                            yield sprintf(
+                                '%s $%s%s,',
+                                $this->dumpPHPType($phpType, $generator->import(...)),
+                                $name,
+                                $phpType instanceof SymfonyType\NullableType ? ' = null' : '',
+                            );
+                        }
+                    });
+
                     yield '';
-                    yield from $generator->docComment(function () use ($failedException, $generator, $variables) {
+                    yield from $generator->docComment(function () use ($generator, $variables) {
                         foreach ($variables as $name => $phpType) {
                             if ( ! $phpType instanceof SymfonyType\CollectionType) {
                                 continue;
@@ -124,42 +90,104 @@ final class OperationClassGenerator extends AbstractGenerator
                                 $name,
                             );
                         }
-
-                        yield sprintf('@throws %s', $generator->import($failedException));
                     });
 
                     if ($variables !== []) {
-                        yield 'public function executeOrThrow(';
+                        yield 'public function execute(';
                         yield $parameters;
-                        yield sprintf(') : %s {', $generator->import(sprintf($namespace . '\\%s\Data', $queryClassName)));
+                        yield sprintf(
+                            ') : %s {',
+                            $generator->import(sprintf($namespace . '\\%s\Data', $plan->queryClassName)),
+                        );
                     } else {
-                        yield sprintf('public function executeOrThrow() : %s', $generator->import(sprintf($namespace . '\\%s\Data', $queryClassName)));
+                        yield sprintf(
+                            'public function execute() : %s',
+                            $generator->import(sprintf($namespace . '\\%s\Data', $plan->queryClassName)),
+                        );
                         yield '{';
                     }
 
-                    yield $generator->indent(function () use ($failedException, $generator, $variables) {
-                        yield '$data = $this->execute(';
-                        yield $generator->indent(function () use ($variables) {
-                            foreach ($variables as $name => $phpType) {
-                                yield sprintf('$%s,', $name);
-                            }
+                    yield $generator->indent(function () use ($generator, $variables) {
+                        yield '$data = $this->client->graphql(';
+                        yield $generator->indent(function () use ($generator, $variables) {
+                            yield 'self::OPERATION_DEFINITION,';
+                            yield '[';
+                            yield $generator->indent(function () use ($variables) {
+                                foreach ($variables as $name => $phpType) {
+                                    yield sprintf("'%s' => \$%s,", $name, $name);
+                                }
+                            });
+                            yield '],';
+                            yield 'self::OPERATION_NAME,';
                         });
                         yield ');';
-
                         yield '';
-                        yield 'if ($data->errors !== []) {';
+                        yield 'return new Data(';
                         yield $generator->indent([
-                            sprintf('throw new %s($data);', $generator->import($failedException)),
+                            "\$data['data'] ?? [], // @phpstan-ignore argument.type",
+                            "\$data['errors'] ?? [] // @phpstan-ignore argument.type",
                         ]);
-                        yield '}';
-
-                        yield '';
-                        yield 'return $data;';
+                        yield ');';
                     });
                     yield '}';
-                }
-            }),
-            '}',
-        ]);
+
+                    if ($this->config->dumpOrThrows) {
+                        yield '';
+                        yield from $generator->docComment(function () use ($failedException, $generator, $variables) {
+                            foreach ($variables as $name => $phpType) {
+                                if ( ! $phpType instanceof SymfonyType\CollectionType) {
+                                    continue;
+                                }
+
+                                yield sprintf(
+                                    '@param %s $%s',
+                                    TypeDumper::dump($phpType, $generator->import(...)),
+                                    $name,
+                                );
+                            }
+
+                            yield sprintf('@throws %s', $generator->import($failedException));
+                        });
+
+                        if ($variables !== []) {
+                            yield 'public function executeOrThrow(';
+                            yield $parameters;
+                            yield sprintf(
+                                ') : %s {',
+                                $generator->import(sprintf($namespace . '\\%s\Data', $plan->queryClassName)),
+                            );
+                        } else {
+                            yield sprintf(
+                                'public function executeOrThrow() : %s',
+                                $generator->import(sprintf($namespace . '\\%s\Data', $plan->queryClassName)),
+                            );
+                            yield '{';
+                        }
+
+                        yield $generator->indent(function () use ($failedException, $generator, $variables) {
+                            yield '$data = $this->execute(';
+                            yield $generator->indent(function () use ($variables) {
+                                foreach ($variables as $name => $phpType) {
+                                    yield sprintf('$%s,', $name);
+                                }
+                            });
+                            yield ');';
+
+                            yield '';
+                            yield 'if ($data->errors !== []) {';
+                            yield $generator->indent([
+                                sprintf('throw new %s($data);', $generator->import($failedException)),
+                            ]);
+                            yield '}';
+
+                            yield '';
+                            yield 'return $data;';
+                        });
+                        yield '}';
+                    }
+                },
+            );
+            yield '}';
+        });
     }
 }

--- a/src/GraphQL/DocumentNodeWithSource.php
+++ b/src/GraphQL/DocumentNodeWithSource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\FragmentDefinitionNode;
+use GraphQL\Language\AST\NodeList;
+
+final class DocumentNodeWithSource extends DocumentNode
+{
+    public string $source;
+
+    public static function create(DocumentNode $documentNode, string $source) : self
+    {
+        $definitions = [];
+        foreach ($documentNode->definitions as $definition) {
+            if ($definition instanceof FragmentDefinitionNode) {
+                $definition = FragmentDefinitionNodeWithSource::create($definition, $source);
+            }
+
+            $definitions[] = $definition;
+        }
+
+        return new self([
+            'definitions' => new NodeList($definitions),
+            'source' => $source,
+        ]);
+    }
+}

--- a/src/GraphQL/FragmentDefinitionNodeWithSource.php
+++ b/src/GraphQL/FragmentDefinitionNodeWithSource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use GraphQL\Language\AST\FragmentDefinitionNode;
+
+final class FragmentDefinitionNodeWithSource extends FragmentDefinitionNode
+{
+    public string $source;
+
+    public static function create(FragmentDefinitionNode $fragmentNode, string $source) : self
+    {
+        return new self([
+            'name' => $fragmentNode->name,
+            'variableDefinitions' => $fragmentNode->variableDefinitions,
+            'typeCondition' => $fragmentNode->typeCondition,
+            'directives' => $fragmentNode->directives,
+            'selectionSet' => $fragmentNode->selectionSet,
+            'source' => $source,
+        ]);
+    }
+}

--- a/src/Optimizer.php
+++ b/src/Optimizer.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator;
 
 use Exception;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Type\Schema;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\Visitor\DuplicateFieldOptimizer;
 use Ruudk\GraphQLCodeGenerator\Visitor\FragmentOptimizer;
 use Ruudk\GraphQLCodeGenerator\Visitor\IncludeAndSkipDirectiveOptimizer;
@@ -17,7 +17,7 @@ use Ruudk\GraphQLCodeGenerator\Visitor\TypeNameVisitor;
 final readonly class Optimizer
 {
     /**
-     * @var list<callable(Node, array<string, array{FragmentDefinitionNode, list<string>}>): Node>
+     * @var list<callable(Node, array<string, array{FragmentDefinitionNodeWithSource, list<string>}>): Node>
      */
     private array $visitors;
 
@@ -36,7 +36,7 @@ final readonly class Optimizer
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      * @throws Exception
      * @return T
      */

--- a/src/PHP/Visitor/ClassConstantFinder.php
+++ b/src/PHP/Visitor/ClassConstantFinder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+final class ClassConstantFinder extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, String_>
+     */
+    public private(set) array $constants = [];
+
+    #[Override]
+    public function enterNode(Node $node) : null
+    {
+        if ( ! $node instanceof Node\Stmt\ClassConst) {
+            return null;
+        }
+
+        foreach ($node->consts as $const) {
+            if ( ! $const->value instanceof String_) {
+                continue;
+            }
+
+            $this->constants[$const->name->toString()] = $const->value;
+        }
+
+        return null;
+    }
+}

--- a/src/PHP/Visitor/OperationFinder.php
+++ b/src/PHP/Visitor/OperationFinder.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use Override;
+use PhpParser\NameContext;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Webmozart\Assert\InvalidArgumentException;
+
+final class OperationFinder extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, array<string, array<string, string>>>
+     */
+    public private(set) array $operations = [];
+    private ?string $className = null;
+
+    /**
+     * @param array<string, String_> $constants
+     */
+    public function __construct(
+        private array $constants,
+        private NameContext $context,
+    ) {}
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    #[Override]
+    public function enterNode(Node $node) : null
+    {
+        if ($node instanceof Node\Stmt\Class_ && $node->name !== null) {
+            $this->className = Name::concat($this->context->getNamespace(), (string) $node->name)?->toString();
+
+            return null;
+        }
+
+        if ( ! $node instanceof Node\Stmt\ClassMethod) {
+            return null;
+        }
+
+        foreach ($node->params as $param) {
+            if ( ! $param->var instanceof Node\Expr\Variable) {
+                continue;
+            }
+
+            if ( ! is_string($param->var->name)) {
+                continue;
+            }
+
+            foreach ($param->attrGroups as $attrGroup) {
+                foreach ($attrGroup->attrs as $attr) {
+                    if ($this->context->getResolvedClassName($attr->name)->toString() !== GeneratedGraphQLClient::class) {
+                        continue;
+                    }
+
+                    if (count($attr->args) !== 1) {
+                        continue;
+                    }
+
+                    $arg = $attr->args[0];
+
+                    $value = $arg->value;
+
+                    if ($value instanceof Node\Expr\ClassConstFetch && $value->name instanceof Node\Identifier) {
+                        $value = $this->constants[$value->name->toString()];
+                    }
+
+                    if ( ! $value instanceof String_) {
+                        throw new InvalidArgumentException('Invalid argument type');
+                    }
+
+                    $this->operations[$this->className][$node->name->toString()][$param->var->name] = $value->value;
+
+                    continue 3;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    #[Override]
+    public function leaveNode(Node $node) : null
+    {
+        if ( ! $node instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
+        $this->className = null;
+
+        return null;
+    }
+}

--- a/src/PHP/Visitor/OperationInjector.php
+++ b/src/PHP/Visitor/OperationInjector.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\NodeVisitorAbstract;
+
+final class OperationInjector extends NodeVisitorAbstract
+{
+    /**
+     * @param array<string, array<string, string>> $operations
+     */
+    public function __construct(
+        private array $operations,
+    ) {}
+
+    #[Override]
+    public function enterNode(Node $node) : ?Node
+    {
+        if ( ! $node instanceof Node\Stmt\ClassMethod) {
+            return null;
+        }
+
+        if ( ! isset($this->operations[$node->name->toString()])) {
+            return null;
+        }
+
+        $changed = false;
+
+        foreach ($node->params as $param) {
+            if ( ! $param->var instanceof Node\Expr\Variable) {
+                continue;
+            }
+
+            if ( ! is_string($param->var->name)) {
+                continue;
+            }
+
+            if ( ! isset($this->operations[$node->name->toString()][$param->var->name])) {
+                continue;
+            }
+
+            $param->type = new Name(new Name($this->operations[$node->name->toString()][$param->var->name])->getLast());
+
+            $changed = true;
+        }
+
+        if ( ! $changed) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/src/PHP/Visitor/UseStatementInserter.php
+++ b/src/PHP/Visitor/UseStatementInserter.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
+use PhpParser\NodeVisitorAbstract;
+
+final class UseStatementInserter extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $insertedFqcns = [];
+
+    /**
+     * @var list<string>
+     */
+    private array $fqcnsToInsert;
+
+    /**
+     * @param list<string> $fqcns
+     */
+    public function __construct(
+        array $fqcns,
+    ) {
+        // Remove duplicates and sort the FQCNs
+        $this->fqcnsToInsert = array_values(array_unique($fqcns));
+        sort($this->fqcnsToInsert, SORT_STRING | SORT_FLAG_CASE);
+    }
+
+    /**
+     * @return null|array<Node>
+     */
+    #[Override]
+    public function enterNode(Node $node) : ?array
+    {
+        // Only process Use_ nodes
+        if ( ! $node instanceof Use_) {
+            return null;
+        }
+
+        // Get the current use statement's name
+        $currentName = $node->uses[0]->name->toString();
+
+        // Mark this FQCN as already existing if it's in our list
+        if (in_array($currentName, $this->fqcnsToInsert, true)) {
+            $this->insertedFqcns[$currentName] = true;
+        }
+
+        // Collect all FQCNs that should be inserted before this node
+        $toInsertBefore = [];
+        foreach ($this->fqcnsToInsert as $fqcn) {
+            if (isset($this->insertedFqcns[$fqcn])) {
+                continue;
+            }
+
+            if (strcasecmp($fqcn, $currentName) < 0) {
+                $toInsertBefore[] = $fqcn;
+                $this->insertedFqcns[$fqcn] = true;
+            }
+        }
+
+        if ($toInsertBefore !== []) {
+            return $this->insertMultipleBefore($node, $toInsertBefore);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return null|array<Node>
+     */
+    #[Override]
+    public function leaveNode(Node $node) : ?array
+    {
+        if ( ! $node instanceof Use_) {
+            return null;
+        }
+
+        $currentName = $node->uses[0]->name->toString();
+
+        // Get parent and find next sibling
+        $parent = $node->getAttribute('parent');
+        $key = $node->getAttribute('key');
+
+        if ( ! is_int($key)) {
+            return null;
+        }
+
+        // Use statements can be in a Namespace or at the root level
+        // By checking the specific parent types, we avoid dynamic property access
+        $stmts = null;
+
+        if ($parent instanceof Namespace_) {
+            $stmts = $parent->stmts;
+        } elseif (is_array($parent)) {
+            // Root level - parent is the statements array itself
+            $stmts = $parent;
+        }
+
+        if ($stmts === null) {
+            return null;
+        }
+
+        $nextIndex = $key + 1;
+
+        // Determine what FQCNs should be inserted after this node
+        $toInsertAfter = [];
+
+        // If there's no next statement or next is not a Use_, insert remaining after current
+        if ( ! isset($stmts[$nextIndex]) || ! ($stmts[$nextIndex] instanceof Use_)) {
+            // This is the last use statement, insert all remaining that come after
+            foreach ($this->fqcnsToInsert as $fqcn) {
+                if (isset($this->insertedFqcns[$fqcn])) {
+                    continue;
+                }
+
+                if (strcasecmp($fqcn, $currentName) > 0) {
+                    $toInsertAfter[] = $fqcn;
+                    $this->insertedFqcns[$fqcn] = true;
+                }
+            }
+        } else {
+            // Check next Use_ statement
+            $nextUse = $stmts[$nextIndex];
+            $nextName = $nextUse->uses[0]->name->toString();
+
+            // Find FQCNs that should go between current and next
+            foreach ($this->fqcnsToInsert as $fqcn) {
+                if (isset($this->insertedFqcns[$fqcn])) {
+                    continue;
+                }
+
+                if (strcasecmp($fqcn, $currentName) > 0 && strcasecmp($fqcn, $nextName) < 0) {
+                    $toInsertAfter[] = $fqcn;
+                    $this->insertedFqcns[$fqcn] = true;
+                }
+            }
+        }
+
+        if ($toInsertAfter !== []) {
+            return $this->insertMultipleAfter($node, $toInsertAfter);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Node> $nodes
+     * @return null|array<Node>
+     */
+    #[Override]
+    public function afterTraverse(array $nodes) : ?array
+    {
+        // Check if there are any FQCNs that haven't been inserted yet
+        $remainingFqcns = [];
+        foreach ($this->fqcnsToInsert as $fqcn) {
+            if ( ! isset($this->insertedFqcns[$fqcn])) {
+                $remainingFqcns[] = $fqcn;
+            }
+        }
+
+        if ($remainingFqcns === []) {
+            return null;
+        }
+
+        // Find the namespace node and insert remaining FQCNs
+        foreach ($nodes as $node) {
+            if ($node instanceof Namespace_) {
+                $this->handleNamespaceNode($node, $remainingFqcns);
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $fqcns
+     */
+    private function handleNamespaceNode(Namespace_ $namespace, array $fqcns) : void
+    {
+        $firstNonUseIndex = null;
+        $lastUseIndex = null;
+
+        foreach ($namespace->stmts as $index => $stmt) {
+            if ($stmt instanceof Use_) {
+                $lastUseIndex = (int) $index;
+            } elseif ($firstNonUseIndex === null) {
+                $firstNonUseIndex = (int) $index;
+            }
+        }
+
+        // Create use statements for all remaining FQCNs
+        $newUses = [];
+        foreach ($fqcns as $fqcn) {
+            $newUses[] = new Use_([
+                new UseUse(new Node\Name($fqcn)),
+            ]);
+            $this->insertedFqcns[$fqcn] = true;
+        }
+
+        // If no use statements exist, insert at the beginning (after namespace)
+        if ($lastUseIndex === null) {
+            if ($firstNonUseIndex !== null) {
+                array_splice($namespace->stmts, 0, 0, $newUses);
+            } else {
+                $namespace->stmts = array_merge($newUses, $namespace->stmts);
+            }
+        } else {
+            // Insert after the last use statement
+            array_splice($namespace->stmts, $lastUseIndex + 1, 0, $newUses);
+        }
+    }
+
+    /**
+     * @param list<string> $fqcns
+     * @return array<Node>
+     */
+    private function insertMultipleBefore(Use_ $node, array $fqcns) : array
+    {
+        $newUses = [];
+        foreach ($fqcns as $fqcn) {
+            $newUses[] = new Use_([
+                new UseUse(new Node\Name($fqcn)),
+            ]);
+        }
+
+        return array_merge($newUses, [$node]);
+    }
+
+    /**
+     * @param list<string> $fqcns
+     * @return array<Node>
+     */
+    private function insertMultipleAfter(Use_ $node, array $fqcns) : array
+    {
+        $newUses = [$node];
+        foreach ($fqcns as $fqcn) {
+            $newUses[] = new Use_([
+                new UseUse(new Node\Name($fqcn)),
+            ]);
+        }
+
+        return $newUses;
+    }
+}

--- a/src/PHPStan/RestrictedUsageExtension.php
+++ b/src/PHPStan/RestrictedUsageExtension.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan;
+
+use Override;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\ExtendedPropertyReflection;
+use PHPStan\Rules\ClassNameUsageLocation;
+use PHPStan\Rules\RestrictedUsage\RestrictedClassNameUsageExtension;
+use PHPStan\Rules\RestrictedUsage\RestrictedMethodUsageExtension;
+use PHPStan\Rules\RestrictedUsage\RestrictedPropertyUsageExtension;
+use PHPStan\Rules\RestrictedUsage\RestrictedUsage;
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
+use Ruudk\GraphQLCodeGenerator\Config\ConfigException;
+use Ruudk\GraphQLCodeGenerator\Config\ConfigLoader;
+
+final readonly class RestrictedUsageExtension implements RestrictedClassNameUsageExtension, RestrictedPropertyUsageExtension, RestrictedMethodUsageExtension
+{
+    /**
+     * @var list<string>
+     */
+    private array $namespaces;
+
+    /**
+     * @param list<string> $configs
+     * @throws ConfigException
+     */
+    public function __construct(
+        array $configs,
+    ) {
+        $this->namespaces = array_map(
+            fn($config) => $config->namespace,
+            ConfigLoader::load(...$configs),
+        );
+    }
+
+    #[Override]
+    public function isRestrictedClassNameUsage(
+        ClassReflection $classReflection,
+        Scope $scope,
+        ClassNameUsageLocation $location,
+    ) : ?RestrictedUsage {
+        if ($location->value === ClassNameUsageLocation::INSTANTIATION) {
+            foreach ($this->namespaces as $namespace) {
+                $pattern = sprintf('/^%s\\\(Query|Mutation)\\\Inline\w{6}(Query|Mutation)$/', preg_quote($namespace, '/'));
+
+                if (preg_match($pattern, $classReflection->getName()) === 1) {
+                    return null;
+                }
+            }
+        }
+
+        return $this->isAllowed(
+            $classReflection,
+            $scope,
+            $location->createMessage(sprintf(
+                '%s is only allowed to be used from within',
+                $classReflection->getDisplayName(),
+            )),
+            $location->createIdentifier('graphql.inline.class.restricted'),
+        );
+    }
+
+    #[Override]
+    public function isRestrictedMethodUsage(
+        ExtendedMethodReflection $methodReflection,
+        Scope $scope,
+    ) : ?RestrictedUsage {
+        if ($methodReflection->getName() === '__construct') {
+            return null;
+        }
+
+        return $this->isAllowed(
+            $methodReflection->getDeclaringClass(),
+            $scope,
+            sprintf(
+                'Method %s from %s is only allowed to be used from within',
+                $methodReflection->getName(),
+                $methodReflection->getDeclaringClass()->getDisplayName(),
+            ),
+            'graphql.inline.method.restricted',
+        );
+    }
+
+    #[Override]
+    public function isRestrictedPropertyUsage(
+        ExtendedPropertyReflection $propertyReflection,
+        Scope $scope,
+    ) : ?RestrictedUsage {
+        return $this->isAllowed(
+            $propertyReflection->getDeclaringClass(),
+            $scope,
+            sprintf(
+                'Property %s from %s is only allowed to be used from within',
+                $propertyReflection->getName(),
+                $propertyReflection->getDeclaringClass()->getDisplayName(),
+            ),
+            'graphql.inline.property.restricted',
+        );
+    }
+
+    private function isAllowed(
+        ClassReflection $reflection,
+        Scope $scope,
+        string $errorMessage,
+        string $identifier,
+    ) : ?RestrictedUsage {
+        if ( ! $scope->isInClass()) {
+            return null;
+        }
+
+        $sourceReflection = $scope->getClassReflection();
+
+        if ($sourceReflection === null) {
+            return null;
+        }
+
+        // Check if target is generated
+        if ( ! array_any($this->namespaces, fn($namespace) => str_starts_with($reflection->getName(), $namespace))) {
+            return null;
+        }
+
+        // Generated code can always access other generated code.
+        if (array_any($this->namespaces, fn($namespace) => str_starts_with($sourceReflection->getName(), $namespace))) {
+            return null;
+        }
+
+        $source = null;
+        foreach ($reflection->getNativeReflection()->getAttributes() as $attribute) {
+            if ($attribute->getName() !== GeneratedFrom::class) {
+                continue;
+            }
+
+            $source = $attribute->getArguments()['source'];
+
+            break;
+        }
+
+        if ( ! is_string($source)) {
+            return null;
+        }
+
+        if ($sourceReflection->getName() === $source) {
+            return null;
+        }
+
+        return RestrictedUsage::create(
+            sprintf('%s %s', $errorMessage, $source),
+            $identifier,
+        );
+    }
+}

--- a/src/Planner/OperationPlan.php
+++ b/src/Planner/OperationPlan.php
@@ -24,7 +24,6 @@ final readonly class OperationPlan
         public string $queryClassName,
         public string $operationDefinition,
         public array $variables,
-        public string $relativeFilePath,
         public DataClassPlan $dataClass,
         public OperationClassPlan $operationClass,
         public ErrorClassPlan $errorClass,

--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -18,7 +18,8 @@ final readonly class DataClassPlan
      * @param array<string, list<string>> $inlineFragmentRequiredFields
      */
     public function __construct(
-        public string $relativePath,
+        public string $source,
+        public string $path,
         public string $fqcn,
         public NamedType & Type $parentType,
         public SymfonyType $fields,

--- a/src/Planner/Plan/EnumClassPlan.php
+++ b/src/Planner/Plan/EnumClassPlan.php
@@ -10,7 +10,7 @@ final readonly class EnumClassPlan
      * @param array<string, array{value: string, description: ?string}> $values
      */
     public function __construct(
-        public string $relativePath,
+        public string $path,
         public string $typeName,
         public ?string $description,
         public array $values,

--- a/src/Planner/Plan/ErrorClassPlan.php
+++ b/src/Planner/Plan/ErrorClassPlan.php
@@ -7,7 +7,7 @@ namespace Ruudk\GraphQLCodeGenerator\Planner\Plan;
 final readonly class ErrorClassPlan
 {
     public function __construct(
-        public string $relativePath,
+        public string $path,
         public string $operationType,
         public string $operationName,
     ) {}

--- a/src/Planner/Plan/ExceptionClassPlan.php
+++ b/src/Planner/Plan/ExceptionClassPlan.php
@@ -7,7 +7,7 @@ namespace Ruudk\GraphQLCodeGenerator\Planner\Plan;
 final readonly class ExceptionClassPlan
 {
     public function __construct(
-        public string $relativePath,
+        public string $path,
         public string $operationType,
         public string $operationName,
         public string $exceptionClassName,

--- a/src/Planner/Plan/InputClassPlan.php
+++ b/src/Planner/Plan/InputClassPlan.php
@@ -12,7 +12,7 @@ final readonly class InputClassPlan
      * @param array<string, array{type: SymfonyType, required: bool, description: ?string}> $fields
      */
     public function __construct(
-        public string $relativePath,
+        public string $path,
         public string $typeName,
         public ?string $description,
         public bool $isOneOf,

--- a/src/Planner/Plan/NodeNotFoundExceptionPlan.php
+++ b/src/Planner/Plan/NodeNotFoundExceptionPlan.php
@@ -7,6 +7,6 @@ namespace Ruudk\GraphQLCodeGenerator\Planner\Plan;
 final readonly class NodeNotFoundExceptionPlan
 {
     public function __construct(
-        public string $relativePath,
+        public string $path,
     ) {}
 }

--- a/src/Planner/Plan/OperationClassPlan.php
+++ b/src/Planner/Plan/OperationClassPlan.php
@@ -13,7 +13,7 @@ final readonly class OperationClassPlan
      * @param array<non-empty-string, array{required: bool, typeNode: null|TypeNode, type: SymfonyType}> $variables
      */
     public function __construct(
-        public string $relativePath,
+        public string $path,
         public string $fqcn,
         public string $operationName,
         public string $operationType,
@@ -21,5 +21,6 @@ final readonly class OperationClassPlan
         public string $operationDefinition,
         public array $variables,
         public string $relativeFilePath,
+        public string $source,
     ) {}
 }

--- a/src/Planner/PlannerResult.php
+++ b/src/Planner/PlannerResult.php
@@ -32,12 +32,17 @@ final class PlannerResult
     public private(set) array $discoveredInputObjectTypes = [];
 
     /**
-     * @param object $class A plan object with a relativePath property
+     * @var array<string, array<string, array<string, string>>>
+     */
+    public private(set) array $operationsToInject = [];
+
+    /**
+     * @param object $class A plan object with a path property
      */
     public function addClass(object $class) : void
     {
-        /** @var object{relativePath: string} $class */
-        $this->classes[$class->relativePath] = $class;
+        /** @var object{path: string} $class */
+        $this->classes[$class->path] = $class;
     }
 
     public function addOperation(OperationPlan $operation) : void
@@ -59,5 +64,13 @@ final class PlannerResult
     public function setDiscoveredInputObjectTypes(array $inputObjectTypes) : void
     {
         $this->discoveredInputObjectTypes = $inputObjectTypes;
+    }
+
+    /**
+     * @param array<string, array<string, array<string, string>>> $operationsToInject
+     */
+    public function setOperationsToInject(array $operationsToInject) : void
+    {
+        $this->operationsToInject = $operationsToInject;
     }
 }

--- a/src/Visitor/DuplicateFieldOptimizer.php
+++ b/src/Visitor/DuplicateFieldOptimizer.php
@@ -6,12 +6,12 @@ namespace Ruudk\GraphQLCodeGenerator\Visitor;
 
 use Exception;
 use GraphQL\Language\AST\FieldNode;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\Visitor;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -20,7 +20,7 @@ final readonly class DuplicateFieldOptimizer
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      *
      * @throws InvalidArgumentException
      * @throws Exception

--- a/src/Visitor/FragmentOptimizer.php
+++ b/src/Visitor/FragmentOptimizer.php
@@ -11,6 +11,7 @@ use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Visitor;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -22,7 +23,7 @@ final readonly class FragmentOptimizer
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      * @throws InvalidArgumentException
      * @throws Exception
      * @return T

--- a/src/Visitor/IncludeAndSkipDirectiveOptimizer.php
+++ b/src/Visitor/IncludeAndSkipDirectiveOptimizer.php
@@ -7,10 +7,10 @@ namespace Ruudk\GraphQLCodeGenerator\Visitor;
 use Exception;
 use GraphQL\Language\AST\BooleanValueNode;
 use GraphQL\Language\AST\FieldNode;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Visitor;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -19,7 +19,7 @@ final readonly class IncludeAndSkipDirectiveOptimizer
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      *
      * @throws InvalidArgumentException
      * @throws Exception

--- a/src/Visitor/InlineFragmentOptimizer.php
+++ b/src/Visitor/InlineFragmentOptimizer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\Visitor;
 
 use Exception;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
@@ -14,6 +13,7 @@ use GraphQL\Language\Visitor;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -26,7 +26,7 @@ final readonly class InlineFragmentOptimizer
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      *
      * @throws InvalidArgumentException
      * @throws Exception

--- a/src/Visitor/TypeNameVisitor.php
+++ b/src/Visitor/TypeNameVisitor.php
@@ -6,7 +6,6 @@ namespace Ruudk\GraphQLCodeGenerator\Visitor;
 
 use Exception;
 use GraphQL\Language\AST\FieldNode;
-use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NameNode;
@@ -20,6 +19,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -32,7 +32,7 @@ final readonly class TypeNameVisitor
     /**
      * @template T of Node
      * @param T $node
-     * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
+     * @param array<string, array{FragmentDefinitionNodeWithSource, list<string>}> $fragmentDefinitions
      *
      * @throws InvalidArgumentException
      * @throws Exception

--- a/tests/ConnectionNames/ConnectionNamesTest.php
+++ b/tests/ConnectionNames/ConnectionNamesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\ConnectionNames;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\ConnectionNames\Generated\Query\TestQuery;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 

--- a/tests/ConnectionNames/Generated/Query/TestQuery.php
+++ b/tests/ConnectionNames/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\ConnectionNames\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/ConnectionNames/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/DumpDefinitions/DumpDefinitionsTest.php
+++ b/tests/DumpDefinitions/DumpDefinitionsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\DumpDefinitions;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\DumpDefinitions\Generated\Query\TestQuery;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 

--- a/tests/DumpDefinitions/Generated/Query/TestQuery.php
+++ b/tests/DumpDefinitions/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\DumpDefinitions\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/DumpDefinitions/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/DumpOrThrows/DumpOrThrowsTest.php
+++ b/tests/DumpOrThrows/DumpOrThrowsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\DumpOrThrows;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\DumpOrThrows\Generated\Query\TestQuery;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 

--- a/tests/DumpOrThrows/Generated/Query/TestQuery.php
+++ b/tests/DumpOrThrows/Generated/Query/TestQuery.php
@@ -9,7 +9,6 @@ use Ruudk\GraphQLCodeGenerator\DumpOrThrows\Generated\Query\Test\TestQueryFailed
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/DumpOrThrows/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\Enum;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Enum\Generated\Enum\Role;
 use Ruudk\GraphQLCodeGenerator\Enum\Generated\Enum\State;
 use Ruudk\GraphQLCodeGenerator\Enum\Generated\Query\TestQuery;

--- a/tests/Enum/Generated/Query/TestQuery.php
+++ b/tests/Enum/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Enum\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/Enum/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/EnumDumpIsMethods/EnumDumpIsMethodsTest.php
+++ b/tests/EnumDumpIsMethods/EnumDumpIsMethodsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\EnumDumpIsMethods;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\EnumDumpIsMethods\Generated\Enum\Role;
 use Ruudk\GraphQLCodeGenerator\EnumDumpIsMethods\Generated\Enum\State;
 use Ruudk\GraphQLCodeGenerator\EnumDumpIsMethods\Generated\Query\TestQuery;

--- a/tests/EnumDumpIsMethods/Generated/Query/TestQuery.php
+++ b/tests/EnumDumpIsMethods/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\EnumDumpIsMethods\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/EnumDumpIsMethods/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdminQuery.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdminQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\FragmentIsolation\Generated\Query\GetWorkflowForA
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/FragmentIsolation/Test.graphql
 
 final readonly class GetWorkflowForAdminQuery {
     public const string OPERATION_NAME = 'GetWorkflowForAdmin';

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetailsQuery.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetailsQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\FragmentSpreadBug\Generated\Query\GetTransactionD
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/FragmentSpreadBug/Test.graphql
 
 final readonly class GetTransactionDetailsQuery {
     public const string OPERATION_NAME = 'GetTransactionDetails';

--- a/tests/Fragments/Generated/Query/TestQuery.php
+++ b/tests/Fragments/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Fragments\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/Fragments/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/GraphQLRequestMatcher.php
+++ b/tests/GraphQLRequestMatcher.php
@@ -25,7 +25,7 @@ final readonly class GraphQLRequestMatcher implements RequestMatcherInterface
      */
     public function __construct(
         private ?array $variables = null,
-        private string $operationName = 'Test',
+        private ?string $operationName = null,
         ?string $path = null,
         ?string $host = null,
         null | array | string $methods = ['POST'],
@@ -56,7 +56,7 @@ final readonly class GraphQLRequestMatcher implements RequestMatcherInterface
             return false;
         }
 
-        if ($body['operationName'] !== $this->operationName) {
+        if ($this->operationName !== null && $body['operationName'] !== $this->operationName) {
             return false;
         }
 

--- a/tests/IncludeAndSkipDirective/Generated/Query/TestQuery.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/TestQuery.php
@@ -9,7 +9,6 @@ use Ruudk\GraphQLCodeGenerator\IncludeAndSkipDirective\Generated\Query\Test\Test
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/IncludeAndSkipDirective/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/IncludeAndSkipDirective/IncludeAndSkipDirectiveTest.php
+++ b/tests/IncludeAndSkipDirective/IncludeAndSkipDirectiveTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\IncludeAndSkipDirective;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\IncludeAndSkipDirective\Generated\Query\TestQuery;
 

--- a/tests/IndexByDirective/Generated/Query/TestMultiFieldQuery.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiFieldQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiField\D
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/IndexByDirective/TestMultiField.graphql
 
 final readonly class TestMultiFieldQuery {
     public const string OPERATION_NAME = 'TestMultiField';

--- a/tests/IndexByDirective/Generated/Query/TestQuery.php
+++ b/tests/IndexByDirective/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/IndexByDirective/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/IndexByDirective/IndexByDirectiveTest.php
+++ b/tests/IndexByDirective/IndexByDirectiveTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\IndexByDirective;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLRequestMatcher;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\IndexByDirective\Generated\Query\TestMultiFieldQuery;

--- a/tests/InlineFragments/Generated/Query/TestQuery.php
+++ b/tests/InlineFragments/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/InlineFragments/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/InlineProcessing/Generated/Query/Inline1d8480/Data.php
+++ b/tests/InlineProcessing/Generated/Query/Inline1d8480/Data.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480\Data\Viewer;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\SomeController;
+
+// This file was automatically generated and should not be edited.
+
+#[GeneratedFrom(source: SomeController::class)]
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *         'projects': list<array{
+     *             'description': null|string,
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/InlineProcessing/Generated/Query/Inline1d8480/Data/Viewer.php
+++ b/tests/InlineProcessing/Generated/Query/Inline1d8480/Data/Viewer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480\Data;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480\Data\Viewer\Project;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\SomeController;
+
+// This file was automatically generated and should not be edited.
+
+#[GeneratedFrom(source: SomeController::class)]
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     *     'projects': list<array{
+     *         'description': null|string,
+     *         'name': string,
+     *     }>,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineProcessing/Generated/Query/Inline1d8480/Data/Viewer/Project.php
+++ b/tests/InlineProcessing/Generated/Query/Inline1d8480/Data/Viewer/Project.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\SomeController;
+
+// This file was automatically generated and should not be edited.
+
+#[GeneratedFrom(source: SomeController::class)]
+final class Project
+{
+    public ?string $description {
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'description': null|string,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineProcessing/Generated/Query/Inline1d8480/Error.php
+++ b/tests/InlineProcessing/Generated/Query/Inline1d8480/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/InlineProcessing/Generated/Query/Inline1d8480Query.php
+++ b/tests/InlineProcessing/Generated/Query/Inline1d8480Query.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedFrom;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480\Data;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\SomeController;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+#[GeneratedFrom(source: SomeController::class)]
+final readonly class Inline1d8480Query {
+    public const string OPERATION_NAME = 'Inline1d8480';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Inline1d8480 {
+          viewer {
+            login
+            projects {
+              name
+              description
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/InlineProcessing/InlineProcessingTest.php
+++ b/tests/InlineProcessing/InlineProcessingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480Query;
+
+final class InlineProcessingTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->enableGeneratedFromAttribute()
+            ->withInlineProcessingDirectory(__DIR__);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $query = new Inline1d8480Query($this->getClient([
+            'data' => [
+                'viewer' => [
+                    'login' => 'ruudk',
+                    'projects' => [
+                        [
+                            'name' => 'GraphQL Code Generator',
+                            'description' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $result = new SomeController($query)->getResult();
+
+        self::assertSame(['ruudk', 'GraphQL Code Generator'], $result);
+    }
+}

--- a/tests/InlineProcessing/Schema.graphql
+++ b/tests/InlineProcessing/Schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    description: String
+}

--- a/tests/InlineProcessing/SomeController.php
+++ b/tests/InlineProcessing/SomeController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineProcessing;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Ruudk\GraphQLCodeGenerator\InlineProcessing\Generated\Query\Inline1d8480Query;
+
+final readonly class SomeController
+{
+    private const string OPERATION = <<<'GRAPHQL'
+        query {
+            viewer {
+                login
+                projects {
+                    name
+                    description
+                }
+            }
+        }
+        GRAPHQL;
+
+    public function __construct(
+        #[GeneratedGraphQLClient(self::OPERATION)]
+        public Inline1d8480Query $query,
+    ) {}
+
+    /**
+     * @return array{string, string}
+     */
+    public function getResult() : array
+    {
+        $result = $this->query->execute();
+
+        return [
+            $result->viewer->login,
+            $result->viewer->projects[0]->name,
+        ];
+    }
+}

--- a/tests/Money/Generated/Query/ConvertMoneyQuery.php
+++ b/tests/Money/Generated/Query/ConvertMoneyQuery.php
@@ -10,7 +10,6 @@ use Ruudk\GraphQLCodeGenerator\Money\ValueObjects\Money;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/Money/Test.graphql
 
 final readonly class ConvertMoneyQuery {
     public const string OPERATION_NAME = 'ConvertMoney';

--- a/tests/Money/MoneyTest.php
+++ b/tests/Money/MoneyTest.php
@@ -7,7 +7,7 @@ namespace Ruudk\GraphQLCodeGenerator\Money;
 use Generator;
 use Override;
 use Ruudk\CodeGenerator\CodeGenerator;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLRequestMatcher;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\Money\Generated\Query\ConvertMoneyQuery;

--- a/tests/NoIndexBy/Generated/Query/TestQuery.php
+++ b/tests/NoIndexBy/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\NoIndexBy\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/NoIndexBy/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/NoIndexBy/NoIndexByTest.php
+++ b/tests/NoIndexBy/NoIndexByTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\NoIndexBy;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\NoIndexBy\Generated\Query\TestQuery;
 
@@ -15,7 +15,7 @@ final class NoIndexByTest extends GraphQLTestCase
     public function getConfig() : Config
     {
         return parent::getConfig()
-            ->enableAddSymfonyExcludeAttribute()
+            ->enableSymfonyExcludeAttribute()
             ->enableIndexByDirective()
             ->enableAddNodesOnConnections();
     }

--- a/tests/NullableConnections/Generated/Query/TestQuery.php
+++ b/tests/NullableConnections/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\NullableConnections\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/NullableConnections/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/NullableConnections/NullableConnectionsTest.php
+++ b/tests/NullableConnections/NullableConnectionsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\NullableConnections;
 
 use Override;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\NullableConnections\Generated\Query\TestQuery;
 

--- a/tests/OneOfDirective/Generated/Query/TestQuery.php
+++ b/tests/OneOfDirective/Generated/Query/TestQuery.php
@@ -9,7 +9,6 @@ use Ruudk\GraphQLCodeGenerator\OneOfDirective\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/OneOfDirective/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/Optimization/Generated/Query/TestQuery.php
+++ b/tests/Optimization/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/Optimization/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/Planner/NestedFragmentPayloadShapeTest.php
+++ b/tests/Planner/NestedFragmentPayloadShapeTest.php
@@ -7,7 +7,7 @@ namespace Ruudk\GraphQLCodeGenerator\Tests\Planner;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Planner;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
 use SplFileInfo;
@@ -73,7 +73,7 @@ final class NestedFragmentPayloadShapeTest extends TestCase
         // Find the Detail class within ItemWithDetails fragment
         $detailClass = null;
         foreach ($result->classes as $class) {
-            if ($class instanceof DataClassPlan && str_contains($class->relativePath, 'ItemWithDetails/Detail.php')) {
+            if ($class instanceof DataClassPlan && str_contains($class->path, 'ItemWithDetails/Detail.php')) {
                 $detailClass = $class;
 
                 break;
@@ -123,7 +123,7 @@ final class NestedFragmentPayloadShapeTest extends TestCase
         // Find the Payout class within PaymentDetails fragment
         $payoutClass = null;
         foreach ($result->classes as $class) {
-            if ($class instanceof DataClassPlan && str_contains($class->relativePath, 'PaymentDetails/Payout.php')) {
+            if ($class instanceof DataClassPlan && str_contains($class->path, 'PaymentDetails/Payout.php')) {
                 $payoutClass = $class;
 
                 break;

--- a/tests/Planner/SelectionSetPlannerTest.php
+++ b/tests/Planner/SelectionSetPlannerTest.php
@@ -8,8 +8,10 @@ use GraphQL\Language\Parser;
 use GraphQL\Utils\BuildSchema;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\DirectiveProcessor;
+use Ruudk\GraphQLCodeGenerator\GraphQL\DocumentNodeWithSource;
+use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\SelectionSetPlanner;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
@@ -39,11 +41,12 @@ final class SelectionSetPlannerTest extends TestCase
                 metadata { key }
             }
         ');
+        $document = DocumentNodeWithSource::create($document, '');
         // Collect fragments
         $fragments = [];
         $fragmentTypes = [];
         foreach ($document->definitions as $def) {
-            if ($def instanceof \GraphQL\Language\AST\FragmentDefinitionNode) {
+            if ($def instanceof FragmentDefinitionNodeWithSource) {
                 $fragments[$def->name->value] = $def;
                 $type = $schema->getType($def->typeCondition->name->value);
                 self::assertNotNull($type, 'Fragment type ' . $def->typeCondition->name->value . ' should exist');
@@ -97,6 +100,7 @@ final class SelectionSetPlannerTest extends TestCase
         $itemFragment = $fragments['ItemWithDetails'];
         $itemType = $fragmentTypes['ItemWithDetails'];
         $result = $planner->plan(
+            '',
             $itemFragment->selectionSet,
             $itemType,
             '/tmp/generated/Fragment/ItemWithDetails',
@@ -107,7 +111,7 @@ final class SelectionSetPlannerTest extends TestCase
         // Find the Detail class plan in the result
         $detailClassPlan = null;
         foreach ($result->plannerResult->classes as $class) {
-            if ($class instanceof DataClassPlan && str_contains($class->relativePath, 'ItemWithDetails/Detail.php')) {
+            if ($class instanceof DataClassPlan && str_contains($class->path, 'ItemWithDetails/Detail.php')) {
                 $detailClassPlan = $class;
 
                 break;
@@ -154,11 +158,12 @@ final class SelectionSetPlannerTest extends TestCase
                 }
             }
         ');
+        $document = DocumentNodeWithSource::create($document, '');
         // Collect fragments
         $fragments = [];
         $fragmentTypes = [];
         foreach ($document->definitions as $def) {
-            if ($def instanceof \GraphQL\Language\AST\FragmentDefinitionNode) {
+            if ($def instanceof FragmentDefinitionNodeWithSource) {
                 $fragments[$def->name->value] = $def;
                 $type = $schema->getType($def->typeCondition->name->value);
                 self::assertNotNull($type, 'Fragment type ' . $def->typeCondition->name->value . ' should exist');
@@ -212,6 +217,7 @@ final class SelectionSetPlannerTest extends TestCase
         $paymentFragment = $fragments['PaymentDetails'];
         $paymentType = $fragmentTypes['PaymentDetails'];
         $result = $planner->plan(
+            '',
             $paymentFragment->selectionSet,
             $paymentType,
             '/tmp/generated/Fragment/PaymentDetails',
@@ -222,7 +228,7 @@ final class SelectionSetPlannerTest extends TestCase
         // Find the Payout class plan in the result
         $payoutClassPlan = null;
         foreach ($result->plannerResult->classes as $class) {
-            if ($class instanceof DataClassPlan && str_contains($class->relativePath, 'PaymentDetails/Payout.php')) {
+            if ($class instanceof DataClassPlan && str_contains($class->path, 'PaymentDetails/Payout.php')) {
                 $payoutClassPlan = $class;
 
                 break;

--- a/tests/Simple/Generated/Query/TestQuery.php
+++ b/tests/Simple/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\Simple\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/Simple/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/SymfonyExclude/Generated/Query/TestQuery.php
+++ b/tests/SymfonyExclude/Generated/Query/TestQuery.php
@@ -8,7 +8,6 @@ use Ruudk\GraphQLCodeGenerator\SymfonyExclude\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\TestClient;
 
 // This file was automatically generated and should not be edited.
-// Based on tests/SymfonyExclude/Test.graphql
 
 final readonly class TestQuery {
     public const string OPERATION_NAME = 'Test';

--- a/tests/SymfonyExclude/SymfonyExcludeTest.php
+++ b/tests/SymfonyExclude/SymfonyExcludeTest.php
@@ -6,7 +6,7 @@ namespace Ruudk\GraphQLCodeGenerator\SymfonyExclude;
 
 use Override;
 use ReflectionClass;
-use Ruudk\GraphQLCodeGenerator\Config;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\SymfonyExclude\Generated\Query\Test\Data;
 use Ruudk\GraphQLCodeGenerator\SymfonyExclude\Generated\Query\TestQuery;
@@ -17,7 +17,7 @@ final class SymfonyExcludeTest extends GraphQLTestCase
     #[Override]
     public function getConfig() : Config
     {
-        return parent::getConfig()->enableAddSymfonyExcludeAttribute();
+        return parent::getConfig()->enableSymfonyExcludeAttribute();
     }
 
     public function testGenerate() : void


### PR DESCRIPTION
Introduces a new paradigm for GraphQL client code generation that allows developers
to define GraphQL operations directly inline with their code using the
`#[GeneratedGraphQLClient]` attribute. This approach eliminates overfetching and
provides complete visibility into data usage across the codebase.

Key features:
- Define GraphQL operations as class constants with heredoc syntax
- Use `#[GeneratedGraphQLClient(self::OPERATION)]` attribute on constructor parameters
- Automatic type-safe client generation during build process
- PHPStan extension ensures generated classes are only used with class that defines them
- Zero runtime dependencies in generated code

Benefits:
- Prevents lazy overfetching patterns by requiring explicit operation definitions
- Provides clear data flow visibility - know exactly what data is fetched and where
- Compile-time safety through automatic code generation and static analysis
- Encourages minimal, purpose-built queries for each use case
- Maintains type safety throughout the entire data flow

Example usage:
```php
private const string OPERATION = <<<'GRAPHQL'
    query {
        viewer {
            login
            projects { name, description }
        }
    }
    GRAPHQL;

public function __construct(
    #[GeneratedGraphQLClient(self::OPERATION)]
    public Inline1d8480Query $query,  // Type injected at build time
) {}
```
