### PR TITLE
Mark data property in exceptions as `api`

### DIFF
--- a/src/Generator/ExceptionClassGenerator.php
+++ b/src/Generator/ExceptionClassGenerator.php
@@ -22,7 +22,10 @@ final class ExceptionClassGenerator extends AbstractGenerator
             yield '{';
             yield $generator->indent(function () use ($generator, $plan) {
                 yield 'public function __construct(';
-                yield $generator->indent('public readonly Data $data,');
+                yield $generator->indent(function () use ($generator) {
+                    yield from $generator->docComment('@api');
+                    yield 'public readonly Data $data,';
+                });
                 yield ') {';
                 yield $generator->indent(function () use ($generator, $plan) {
                     yield 'parent::__construct(sprintf(';

--- a/tests/DumpOrThrows/Generated/Query/Test/TestQueryFailedException.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/TestQueryFailedException.php
@@ -11,6 +11,9 @@ use Exception;
 final class TestQueryFailedException extends Exception
 {
     public function __construct(
+        /**
+         * @api
+         */
         public readonly Data $data,
     ) {
         parent::__construct(sprintf(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/TestQueryFailedException.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/TestQueryFailedException.php
@@ -11,6 +11,9 @@ use Exception;
 final class TestQueryFailedException extends Exception
 {
     public function __construct(
+        /**
+         * @api
+         */
         public readonly Data $data,
     ) {
         parent::__construct(sprintf(

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/ViewerProjectsQueryFailedException.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/ViewerProjectsQueryFailedException.php
@@ -11,6 +11,9 @@ use Exception;
 final class ViewerProjectsQueryFailedException extends Exception
 {
     public function __construct(
+        /**
+         * @api
+         */
         public readonly Data $data,
     ) {
         parent::__construct(sprintf(

--- a/tests/Twig/Generated/Query/Projectsd4cba6/ProjectsQueryFailedException.php
+++ b/tests/Twig/Generated/Query/Projectsd4cba6/ProjectsQueryFailedException.php
@@ -11,6 +11,9 @@ use Exception;
 final class ProjectsQueryFailedException extends Exception
 {
     public function __construct(
+        /**
+         * @api
+         */
         public readonly Data $data,
     ) {
         parent::__construct(sprintf(


### PR DESCRIPTION
This way, dead-code-detector will not complain about it.
