### PR TITLE
Improve Twig-sourced code generation and restrict usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ enum SearchType: string
     // Returns results matching issues in repositories.
     case IssueAdvanced = 'ISSUE_ADVANCED';
 
+    // Returns results matching issues using hybrid (lexical + semantic) search.
+    case IssueHybrid = 'ISSUE_HYBRID';
+
+    // Returns results matching issues using semantic search.
+    case IssueSemantic = 'ISSUE_SEMANTIC';
+
     // Returns results matching repositories.
     case Repository = 'REPOSITORY';
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4",
         "composer-runtime-api": "^2.0",
         "nikic/php-parser": "^5.6",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.1.18",
         "ruudk/code-generator": "^0.4.4",
         "symfony/console": "^7.4 || ^8.0",
         "symfony/filesystem": "^7.4 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8931a5072831ee21eca3977eabcb5b38",
+    "content-hash": "32a5a30a91518fe6d8f9e12ffc3ff908",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -66,16 +66,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
-            },
+            "version": "2.1.49",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d0082955396e7f5ba19cf298224b85e1099f0ed8",
+                "reference": "d0082955396e7f5ba19cf298224b85e1099f0ed8",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +115,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T19:17:37+00:00"
+            "time": "2026-04-16T21:10:58+00:00"
         },
         {
             "name": "psr/container",

--- a/examples/Generated/Enum/SearchType.php
+++ b/examples/Generated/Enum/SearchType.php
@@ -20,6 +20,12 @@ enum SearchType: string
     // Returns results matching issues in repositories.
     case IssueAdvanced = 'ISSUE_ADVANCED';
 
+    // Returns results matching issues using hybrid (lexical + semantic) search.
+    case IssueHybrid = 'ISSUE_HYBRID';
+
+    // Returns results matching issues using semantic search.
+    case IssueSemantic = 'ISSUE_SEMANTIC';
+
     // Returns results matching repositories.
     case Repository = 'REPOSITORY';
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -32,6 +32,8 @@ pre-commit:
 
     php-cs-fixer:
       glob: "*.php"
+      exclude:
+        - "**/Generated/**"
       run: vendor/bin/php-cs-fixer fix --config .php-cs-fixer.php -- {staged_files}
       stage_fixed: true
 

--- a/phpstan.php
+++ b/phpstan.php
@@ -63,6 +63,14 @@ return [
             ],
             [
                 'identifiers' => [
+                    'shipmonk.deadMethod',
+                ],
+                'paths' => [
+                    __DIR__ . '/tests/PHPStan/Fixtures/*',
+                ],
+            ],
+            [
+                'identifiers' => [
                     'shipmonk.deadConstant',
                 ],
                 'paths' => [

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -12,7 +12,8 @@ use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
 use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQL\AST\Printer;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
 use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
@@ -86,8 +87,16 @@ final class DataClassGenerator extends AbstractGenerator
 
             if ($this->config->addGeneratedAttribute) {
                 yield from $generator->dumpAttribute(Generated::class, function () use ($generator, $plan) {
-                    if ($plan->source instanceof FileSource) {
+                    if ($plan->source instanceof GraphQLFileSource) {
                         yield sprintf('source: %s', var_export($plan->source->relativeFilePath, true));
+
+                        return;
+                    }
+
+                    if ($plan->source instanceof TwigFileSource) {
+                        yield sprintf('source: %s', var_export($plan->source->relativeFilePath, true));
+                        yield 'restricted: true';
+                        yield 'restrictInstantiation: true';
 
                         return;
                     }

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -8,7 +8,7 @@ use JsonException;
 use Ruudk\CodeGenerator\CodeGenerator;
 use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\OperationClassPlan;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 use Symfony\Component\TypeInfo\TypeIdentifier;
@@ -36,7 +36,7 @@ final class OperationClassGenerator extends AbstractGenerator
 
             if ($this->config->addGeneratedAttribute) {
                 yield from $generator->dumpAttribute(Generated::class, function () use ($generator, $plan) {
-                    if ($plan->source instanceof FileSource) {
+                    if ($plan->source instanceof GraphQLFileSource) {
                         yield sprintf('source: %s', var_export($plan->source->relativeFilePath, true));
 
                         return;

--- a/src/GraphQL/DocumentNodeWithSource.php
+++ b/src/GraphQL/DocumentNodeWithSource.php
@@ -7,14 +7,15 @@ namespace Ruudk\GraphQLCodeGenerator\GraphQL;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\NodeList;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 
 final class DocumentNodeWithSource extends DocumentNode
 {
-    public FileSource | InlineSource $source;
+    public GraphQLFileSource | InlineSource | TwigFileSource $source;
 
-    public static function create(DocumentNode $documentNode, FileSource | InlineSource $source) : self
+    public static function create(DocumentNode $documentNode, GraphQLFileSource | InlineSource | TwigFileSource $source) : self
     {
         $definitions = [];
         foreach ($documentNode->definitions as $definition) {

--- a/src/GraphQL/FragmentDefinitionNodeWithSource.php
+++ b/src/GraphQL/FragmentDefinitionNodeWithSource.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\GraphQL;
 
 use GraphQL\Language\AST\FragmentDefinitionNode;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 
 final class FragmentDefinitionNodeWithSource extends FragmentDefinitionNode
 {
-    public FileSource | InlineSource $source;
+    public GraphQLFileSource | InlineSource | TwigFileSource $source;
 
-    public static function create(FragmentDefinitionNode $fragmentNode, FileSource | InlineSource $source) : self
+    public static function create(FragmentDefinitionNode $fragmentNode, GraphQLFileSource | InlineSource | TwigFileSource $source) : self
     {
         return new self([
             'name' => $fragmentNode->name,

--- a/src/PHP/Visitor/OperationFinder.php
+++ b/src/PHP/Visitor/OperationFinder.php
@@ -42,6 +42,10 @@ final class OperationFinder extends NodeVisitorAbstract
             return null;
         }
 
+        if ($this->className === null) {
+            return null;
+        }
+
         foreach ($node->params as $param) {
             if ( ! $param->var instanceof Node\Expr\Variable) {
                 continue;

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -76,8 +76,9 @@ use Ruudk\GraphQLCodeGenerator\Planner\Plan\NodeNotFoundExceptionPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\OperationClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
 use Ruudk\GraphQLCodeGenerator\Planner\SelectionSetPlanner;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLExtension;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLNodeFinder;
 use Ruudk\GraphQLCodeGenerator\Type\TypeHelper;
@@ -252,7 +253,7 @@ final class Planner
 
             $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
                 $document,
-                new FileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
+                new GraphQLFileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
             );
         }
 
@@ -344,7 +345,7 @@ final class Planner
 
                     $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
                         $document,
-                        new FileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
+                        new TwigFileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
                     );
                 }
             }
@@ -615,14 +616,20 @@ final class Planner
 
         Assert::notNull($operation->name, 'Expected operation to have a name');
 
+        if ($document->source instanceof TwigFileSource) {
+            throw new Exception('Twig templates may only contain fragment definitions');
+        }
+
+        $source = $document->source;
+
         $operationName = $operation->name->value;
         $operationNamespaceName = $operationName;
 
-        if ($document->source instanceof InlineSource) {
+        if ($source instanceof InlineSource) {
             $operationNamespaceName = sprintf(
                 '%s%s',
                 $operationName,
-                $document->source->hash,
+                $source->hash,
             );
         }
 
@@ -650,7 +657,7 @@ final class Planner
 
         // Plan the data class and its nested classes
         $planResult = $planner->plan(
-            $document->source,
+            $source,
             $operation->selectionSet,
             $rootType,
             $operationDir . '/Data',
@@ -660,7 +667,7 @@ final class Planner
 
         // Create the data class plan
         $dataClassPlan = new DataClassPlan(
-            $document->source,
+            $source,
             $operationDir . '/Data.php',
             $fqcn,
             $rootType,
@@ -684,7 +691,7 @@ final class Planner
             $operationType,
             $operationDefinition,
             $variables,
-            $document->source,
+            $source,
         );
 
         // Create the error class plan

--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -9,8 +9,9 @@ use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\Type;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 
 final readonly class DataClassPlan
@@ -20,7 +21,7 @@ final readonly class DataClassPlan
      * @param array<string, list<string>> $inlineFragmentRequiredFields
      */
     public function __construct(
-        public FileSource | InlineSource $source,
+        public GraphQLFileSource | InlineSource | TwigFileSource $source,
         public string $path,
         public string $fqcn,
         public NamedType & Type $parentType,

--- a/src/Planner/Plan/OperationClassPlan.php
+++ b/src/Planner/Plan/OperationClassPlan.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\Planner\Plan;
 
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 
@@ -21,6 +21,6 @@ final readonly class OperationClassPlan
         public string $operationType,
         public string $operationDefinition,
         public array $variables,
-        public FileSource | InlineSource $source,
+        public GraphQLFileSource | InlineSource $source,
     ) {}
 }

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -730,9 +730,7 @@ final class SelectionSetPlanner
             }
 
             // Merge path fields from fragment
-            if (isset($fragmentResult->pathFields)) {
-                $pathFields->merge($fragmentResult->pathFields);
-            }
+            $pathFields->merge($fragmentResult->pathFields);
         }
 
         // Note: PayloadShapeBuilder already handles merging fields from fragment spreads

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -30,8 +30,9 @@ use Ruudk\GraphQLCodeGenerator\DirectiveProcessor;
 use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\PossibleTypesFinder;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\RecursiveTypeFinder;
 use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
@@ -93,7 +94,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     public function plan(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         Type $parent,
         string $outputDirectory,
@@ -150,7 +151,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     public function planSelectionSet(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         Type $type,
         PlanningContext $context,
@@ -228,7 +229,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function planNamedTypeSelectionSet(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         NamedType & Type $type,
         PlanningContext $context,
@@ -324,7 +325,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processFieldSelection(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         FieldNode $selection,
         Type $parent,
         PlanningContext $context,
@@ -401,7 +402,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processNestedSelection(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         FieldNode $selection,
         string $fieldName,
         Type $fieldType,
@@ -474,7 +475,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processInlineFragment(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         InlineFragmentNode $selection,
         Type $parent,
         PlanningContext $context,
@@ -1030,7 +1031,7 @@ final class SelectionSetPlanner
      * @throws InvariantViolation
      */
     private function createDataClassPlan(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         NamedType & Type $parentType,
         SelectionSetResult $result,
         PlanningContext $context,
@@ -1076,7 +1077,7 @@ final class SelectionSetPlanner
     }
 
     private function createInlineFragmentClassPlan(
-        FileSource | InlineSource $source,
+        GraphQLFileSource | InlineSource | TwigFileSource $source,
         NamedType & Type $fragmentType,
         FieldCollection $fields,
         PayloadShape $payloadShape,

--- a/src/Planner/Source/GraphQLFileSource.php
+++ b/src/Planner/Source/GraphQLFileSource.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\Planner\Source;
 
-final readonly class FileSource
+final readonly class GraphQLFileSource
 {
     public function __construct(
         public string $relativeFilePath,

--- a/src/Planner/Source/TwigFileSource.php
+++ b/src/Planner/Source/TwigFileSource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Planner\Source;
+
+final readonly class TwigFileSource
+{
+    public function __construct(
+        public string $relativeFilePath,
+    ) {}
+}

--- a/src/TypeInitializer/DelegatingTypeInitializer.php
+++ b/src/TypeInitializer/DelegatingTypeInitializer.php
@@ -21,10 +21,13 @@ final readonly class DelegatingTypeInitializer
     public function __construct(
         TypeInitializer ...$initializers,
     ) {
-        $this->initializers = array_combine(
-            array_map(fn(TypeInitializer $initializer) => $initializer::class, $initializers),
-            $initializers,
-        );
+        $indexed = [];
+
+        foreach ($initializers as $initializer) {
+            $indexed[$initializer::class] = $initializer;
+        }
+
+        $this->initializers = $indexed;
     }
 
     /**

--- a/tests/GraphQLTestCase.php
+++ b/tests/GraphQLTestCase.php
@@ -29,7 +29,9 @@ abstract class GraphQLTestCase extends TestCase
         $parts = explode('\\', static::class);
         array_pop($parts);
         $this->namespace = implode('\\', $parts);
-        $this->directory = __DIR__ . '/' . $parts[array_key_last($parts)];
+        $directoryName = end($parts);
+        Assert::string($directoryName);
+        $this->directory = __DIR__ . '/' . $directoryName;
         $this->client = new Client();
     }
 

--- a/tests/PHPStan/Fixtures/AllowedController.php
+++ b/tests/PHPStan/Fixtures/AllowedController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures;
+
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\Data;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeQuery;
+
+/**
+ * Source of the generated classes — every access below must be allowed.
+ */
+final readonly class AllowedController
+{
+    public function run() : string
+    {
+        $query = new SomeQuery('ruud');
+        $data = $query->execute();
+        $inline = new Data('inline');
+
+        return $data->name . $inline->name;
+    }
+}

--- a/tests/PHPStan/Fixtures/NotAllowedController.php
+++ b/tests/PHPStan/Fixtures/NotAllowedController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures;
+
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\Data;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeQuery;
+
+/**
+ * Not the source — each restricted access below must fire a PHPStan error.
+ */
+final readonly class NotAllowedController
+{
+    public function run() : string
+    {
+        $query = new SomeQuery('ruud');
+        $data = $query->execute();
+        $inline = new Data('inline');
+
+        return $data->name . $inline->name;
+    }
+}

--- a/tests/PHPStan/Generated/Data.php
+++ b/tests/PHPStan/Generated/Data.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan\Generated;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures\AllowedController;
+
+#[Generated(
+    source: AllowedController::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class Data
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/tests/PHPStan/Generated/SomeQuery.php
+++ b/tests/PHPStan/Generated/SomeQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan\Generated;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures\AllowedController;
+
+#[Generated(
+    source: AllowedController::class,
+    restricted: true,
+)]
+final readonly class SomeQuery
+{
+    public function __construct(public string $name)
+    {
+    }
+
+    public function execute() : Data
+    {
+        return new Data($this->name);
+    }
+}

--- a/tests/PHPStan/RestrictedUsageExtensionTest.php
+++ b/tests/PHPStan/RestrictedUsageExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RestrictedUsageExtension::class)]
+final class RestrictedUsageExtensionTest extends TestCase
+{
+    public function testExtension() : void
+    {
+        $command = sprintf(
+            '%s analyse --configuration=%s --no-progress --error-format=raw 2>&1',
+            escapeshellarg(dirname(__DIR__, 2) . '/vendor/bin/phpstan'),
+            escapeshellarg(__DIR__ . '/phpstan.neon'),
+        );
+
+        exec($command, $output, $exitCode);
+
+        self::assertSame(0, $exitCode, sprintf(
+            "PHPStan reported errors for tests/PHPStan fixtures.\n\nOutput:\n%s",
+            implode(PHP_EOL, $output),
+        ));
+    }
+}

--- a/tests/PHPStan/config.php
+++ b/tests/PHPStan/config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+
+return Config::create(
+    schema: __DIR__ . '/schema.docs.graphql',
+    projectDir: __DIR__,
+    queriesDir: __DIR__,
+    outputDir: __DIR__ . '/Generated',
+    namespace: 'Ruudk\GraphQLCodeGenerator\PHPStan\Generated',
+    client: 'DoesnotMatter',
+);

--- a/tests/PHPStan/phpstan.neon
+++ b/tests/PHPStan/phpstan.neon
@@ -1,0 +1,35 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    level: max
+    paths:
+        - Fixtures
+
+    graphQLClientCodeGenerator:
+        configs:
+            - config.php
+
+    ignoreErrors:
+        # Fixtures aren't wired into a real app; silence dead-code detection here.
+        -
+            identifier: shipmonk.deadMethod
+            paths:
+                - Fixtures/*.php
+
+        # Expected restricted-usage errors from NotAllowedController. With
+        # reportUnmatchedIgnoredErrors (default true) the run fails if any
+        # pattern below stops matching — i.e. if the extension regresses and
+        # fails to emit one of the expected restricted-usage errors.
+        -
+            message: '#^Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
+            path: Fixtures/NotAllowedController.php
+            count: 1
+        -
+            message: '#^Method execute from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeQuery is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
+            path: Fixtures/NotAllowedController.php
+            count: 1
+        -
+            message: '#^Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
+            path: Fixtures/NotAllowedController.php
+            count: 2

--- a/tests/Planner/SelectionSetPlannerTest.php
+++ b/tests/Planner/SelectionSetPlannerTest.php
@@ -15,7 +15,7 @@ use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
 use Ruudk\GraphQLCodeGenerator\Planner\SelectionSetPlanner;
-use Ruudk\GraphQLCodeGenerator\Planner\Source\FileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
 use Symfony\Component\String\Inflector\EnglishInflector;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
@@ -43,7 +43,7 @@ final class SelectionSetPlannerTest extends TestCase
                 metadata { key }
             }
         ');
-        $document = DocumentNodeWithSource::create($document, new FileSource(''));
+        $document = DocumentNodeWithSource::create($document, new GraphQLFileSource(''));
         // Collect fragments
         $fragments = [];
         $fragmentTypes = [];
@@ -104,7 +104,7 @@ final class SelectionSetPlannerTest extends TestCase
         $itemFragment = $fragments['ItemWithDetails'];
         $itemType = $fragmentTypes['ItemWithDetails'];
         $planner->plan(
-            new FileSource(''),
+            new GraphQLFileSource(''),
             $itemFragment->selectionSet,
             $itemType,
             '/tmp/generated/Fragment/ItemWithDetails',
@@ -162,7 +162,7 @@ final class SelectionSetPlannerTest extends TestCase
                 }
             }
         ');
-        $document = DocumentNodeWithSource::create($document, new FileSource(''));
+        $document = DocumentNodeWithSource::create($document, new GraphQLFileSource(''));
         // Collect fragments
         $fragments = [];
         $fragmentTypes = [];
@@ -223,7 +223,7 @@ final class SelectionSetPlannerTest extends TestCase
         $paymentFragment = $fragments['PaymentDetails'];
         $paymentType = $fragmentTypes['PaymentDetails'];
         $planner->plan(
-            new FileSource(''),
+            new GraphQLFileSource(''),
             $paymentFragment->selectionSet,
             $paymentType,
             '/tmp/generated/Fragment/PaymentDetails',

--- a/tests/Twig/Generated/Fragment/AdminProjectList.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList.php
@@ -10,7 +10,11 @@ use Ruudk\GraphQLCodeGenerator\Twig\Generated\Fragment\AdminProjectList\Viewer;
 
 // This file was automatically generated and should not be edited.
 
-#[Generated(source: 'tests/Twig/templates/list.html.twig')]
+#[Generated(
+    source: 'tests/Twig/templates/list.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
 final class AdminProjectList
 {
     /**

--- a/tests/Twig/Generated/Fragment/AdminProjectList/Project.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList/Project.php
@@ -9,7 +9,11 @@ use Ruudk\GraphQLCodeGenerator\Twig\Generated\Fragment\AdminProjectRow;
 
 // This file was automatically generated and should not be edited.
 
-#[Generated(source: 'tests/Twig/templates/list.html.twig')]
+#[Generated(
+    source: 'tests/Twig/templates/list.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
 final class Project
 {
     public AdminProjectRow $adminProjectRow {

--- a/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
@@ -8,7 +8,11 @@ use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
 
 // This file was automatically generated and should not be edited.
 
-#[Generated(source: 'tests/Twig/templates/list.html.twig')]
+#[Generated(
+    source: 'tests/Twig/templates/list.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
 final class Viewer
 {
     /**

--- a/tests/Twig/Generated/Fragment/AdminProjectOptions.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectOptions.php
@@ -10,7 +10,11 @@ use Ruudk\GraphQLCodeGenerator\Twig\Generated\NodeNotFoundException;
 
 // This file was automatically generated and should not be edited.
 
-#[Generated(source: 'tests/Twig/templates/_project_options.html.twig')]
+#[Generated(
+    source: 'tests/Twig/templates/_project_options.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
 final class AdminProjectOptions
 {
     public ?ProjectState $state {

--- a/tests/Twig/Generated/Fragment/AdminProjectRow.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectRow.php
@@ -9,7 +9,11 @@ use Ruudk\GraphQLCodeGenerator\Twig\Generated\NodeNotFoundException;
 
 // This file was automatically generated and should not be edited.
 
-#[Generated(source: 'tests/Twig/templates/_project_row.html.twig')]
+#[Generated(
+    source: 'tests/Twig/templates/_project_row.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
 final class AdminProjectRow
 {
     public AdminProjectOptions $adminProjectOptions {


### PR DESCRIPTION
### Exclude Generated dirs from php-cs-fixer hook

Lefthook invokes php-cs-fixer with explicit `{staged_files}`, which overrides the Finder-level `notPath(['Generated'])` exclusion in `.php-cs-fixer.php`. That let the fixer reformat generated fixtures (stripping blank lines between class members) whenever any file inside a `Generated/` dir was staged, causing the generator and fixer to fight each turn.

Add a hook-level `exclude: ["**/Generated/**"]` so generated output is left untouched — it's regenerated by the tool, not hand-edited.

### Restrict Twig-sourced generated classes

Split the single `FileSource` into `GraphQLFileSource` (for `.graphql` files) and `TwigFileSource` (for `.twig` templates) so the generator can distinguish them and treat them differently.

Twig templates render by having the framework instantiate the generated fragment classes for them — userland code shouldn't be constructing or subclassing these. Mark Twig-sourced classes with `restricted: true, restrictInstantiation: true` on the `#[Generated]` attribute so the PHPStan `RestrictedUsageExtension` blocks direct use outside the generating template. `.graphql`-sourced operations stay unrestricted since they're meant to be called explicitly from application code.

`OperationClassPlan` keeps the narrower `GraphQLFileSource | InlineSource` union because Twig templates only contain fragment definitions, never operations; `planOperation` throws early if a Twig source ever reaches it.

### Add functional tests for RestrictedUsageExtension

The PHPStan extension that enforces `#[Generated(restricted: true, restrictInstantiation: true)]` had no direct coverage — only implicit via fixtures asserting the attribute was emitted. A regression in the extension itself (wrong scope check, missing namespace filter, broken attribute parsing) would pass every existing test.

Add a second PHPStan run driven by `tests/PHPStan/phpstan.neon`, invoked as a regular PHPUnit test so it runs as part of the normal test suite:

- `tests/PHPStan/Generated/{Data,SomeQuery}.php` — fake generated   classes with `#[Generated]` pointing at `AllowedController` as   the source. `Data` is fully restricted; `SomeQuery` is restricted   but not `restrictInstantiation`, so anyone can `new` it.
- `tests/PHPStan/Fixtures/AllowedController.php` — the declared   source; must produce zero restricted-usage errors.
- `tests/PHPStan/Fixtures/NotAllowedController.php` — any other   caller; must produce exactly four errors (method, instantiation,   and two property accesses).
- `tests/PHPStan/RestrictedUsageExtensionTest.php` — single   PHPUnit test that shells out to `vendor/bin/phpstan` with the   test neon and asserts exit 0.

Expected errors live in the neon`s `ignoreErrors` block with exact messages and `count:` values. Combined with `reportUnmatchedIgnoredErrors` (default true), the run fails if any expected error stops firing or an unexpected one appears.

Silence `shipmonk.deadMethod` for the fixture dir in the root `phpstan.php` so the main run stays clean.
