### PR TITLE
Remove stale generated imports and improve sync validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "nikic/php-parser": "^5.6",
         "phpstan/phpstan": "^2.1.18",
         "ruudk/code-generator": "^0.4.4",
+        "sebastian/diff": "^7.0",
         "symfony/console": "^7.4 || ^8.0",
         "symfony/filesystem": "^7.4 || ^8.0",
         "symfony/finder": "^7.4 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32a5a30a91518fe6d8f9e12ffc3ff908",
+    "content-hash": "813342ceb2f111e991ca29ae6133466e",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -232,6 +232,73 @@
                 }
             ],
             "time": "2025-09-01T08:09:55+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "symfony/console",
@@ -5514,73 +5581,6 @@
                 }
             ],
             "time": "2025-02-07T04:55:25+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/phpstan.php
+++ b/phpstan.php
@@ -67,6 +67,7 @@ return [
                 ],
                 'paths' => [
                     __DIR__ . '/tests/PHPStan/Fixtures/*',
+                    __DIR__ . '/tests/StaleImportRemoval/ControllerWithStaleImport.php',
                 ],
             ],
             [

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -14,9 +14,12 @@ use Ruudk\GraphQLCodeGenerator\Config\ConfigLoader;
 use Ruudk\GraphQLCodeGenerator\Executor\PlanExecutor;
 use Ruudk\GraphQLCodeGenerator\GraphQL\IndexByDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\Planner;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -161,13 +164,17 @@ final class GenerateCommand
 
                     $errors = false;
 
+                    $differ = new Differ(new UnifiedDiffOutputBuilder("--- Actual\n+++ Expected\n"));
+
                     foreach ($files as $path => $content) {
                         if (isset($actual[$path]) && $content !== $actual[$path]) {
                             $errors = true;
-                            $io->writeln(sprintf('%s content does not match expectations', Path::makeRelative($path, $configItem->projectDir)));
+                            $relativePath = Path::makeRelative($path, $configItem->projectDir);
+                            $io->writeln(sprintf('<error>%s content does not match expectations</error>', $relativePath));
+                            $io->writeln($this->formatDiff($differ->diff($actual[$path], $content)));
                         } elseif ( ! isset($actual[$path])) {
                             $errors = true;
-                            $io->writeln(sprintf('%s does not exist', Path::makeRelative($path, $configItem->projectDir)));
+                            $io->writeln(sprintf('<error>%s does not exist</error>', Path::makeRelative($path, $configItem->projectDir)));
                         }
                     }
 
@@ -213,5 +220,26 @@ final class GenerateCommand
         }
 
         return $exitCode;
+    }
+
+    private function formatDiff(string $diff) : string
+    {
+        $lines = explode("\n", $diff);
+
+        foreach ($lines as $index => $line) {
+            if (str_starts_with($line, '+++') || str_starts_with($line, '---')) {
+                $lines[$index] = sprintf('<comment>%s</comment>', OutputFormatter::escape($line));
+            } elseif (str_starts_with($line, '@@')) {
+                $lines[$index] = sprintf('<fg=cyan>%s</>', OutputFormatter::escape($line));
+            } elseif (str_starts_with($line, '+')) {
+                $lines[$index] = sprintf('<fg=green>%s</>', OutputFormatter::escape($line));
+            } elseif (str_starts_with($line, '-')) {
+                $lines[$index] = sprintf('<fg=red>%s</>', OutputFormatter::escape($line));
+            } else {
+                $lines[$index] = OutputFormatter::escape($line);
+            }
+        }
+
+        return implode("\n", $lines);
     }
 }

--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -25,6 +25,7 @@ use Ruudk\GraphQLCodeGenerator\Generator\NodeNotFoundExceptionGenerator;
 use Ruudk\GraphQLCodeGenerator\Generator\OperationClassGenerator;
 use Ruudk\GraphQLCodeGenerator\GraphQL\AST\Printer;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\OperationInjector;
+use Ruudk\GraphQLCodeGenerator\PHP\Visitor\StaleImportRemover;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\UseStatementInserter;
 use Ruudk\GraphQLCodeGenerator\Planner\OperationPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
@@ -116,6 +117,24 @@ final class PlanExecutor
         }
 
         $printer = new Standard();
+
+        // Build the global set of valid operation FQCNs so StaleImportRemover
+        // only removes imports whose hash no longer corresponds to any planned
+        // operation — regardless of whether the operation is defined in the
+        // current file or elsewhere (e.g. an exception documented via @throws).
+        $validFqcns = [];
+        foreach ($plan->operations as $operation) {
+            $operationFqcn = sprintf(
+                '%s\\%s\\%s\\%s',
+                $this->config->namespace,
+                $operation->operationClass->operationType,
+                $operation->operationClass->operationNamepaceName,
+                $operation->operationClass->className,
+            );
+            $validFqcns[] = $operationFqcn;
+            $validFqcns[] = $operationFqcn . 'FailedException';
+        }
+
         foreach ($plan->operationsToInject as $path => $operations) {
             $oldStmts = $this->phpParser->parse($this->filesystem->readFile($path));
             Assert::notNull($oldStmts, 'Failed to parse PHP file');
@@ -138,6 +157,7 @@ final class PlanExecutor
 
             $newStmts = new NodeTraverser(
                 new NodeConnectingVisitor(),
+                new StaleImportRemover($this->config->namespace, $validFqcns),
                 new UseStatementInserter($fqcns),
             )->traverse($newStmts);
 

--- a/src/PHP/Visitor/StaleImportRemover.php
+++ b/src/PHP/Visitor/StaleImportRemover.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Removes stale use statements for generated GraphQL classes.
+ *
+ * When a file is moved or refactored, the hash in the generated namespace changes.
+ * This visitor removes use statements that match the generated namespace pattern
+ * but don't match the current valid FQCNs.
+ */
+final class StaleImportRemover extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $validFqcns;
+    private string $operationClassPattern;
+
+    /**
+     * @param string $generatedNamespace The namespace for generated classes (e.g., "App\Generated")
+     * @param list<string> $validFqcns The list of valid/current FQCNs to keep
+     */
+    public function __construct(
+        string $generatedNamespace,
+        array $validFqcns,
+    ) {
+        $this->validFqcns = array_fill_keys($validFqcns, true);
+
+        // Match only the operation's leaf classes we generate and can reason about:
+        // the Query/Mutation class itself and its optional FailedException. Sibling
+        // classes (Data\..., Error\...) intentionally fall outside this pattern so
+        // we don't remove them — we have no way to tell if they're stale or still in use.
+        $escapedNamespace = preg_quote($generatedNamespace, '/');
+        $this->operationClassPattern = '/^' . $escapedNamespace . '\\\\(?:Query|Mutation)\\\\[A-Za-z]+[a-f0-9]{6}\\\\[A-Za-z]+(?:Query|Mutation)(?:FailedException)?$/';
+    }
+
+    #[Override]
+    public function enterNode(Node $node) : ?int
+    {
+        if ( ! $node instanceof Use_) {
+            return null;
+        }
+
+        foreach ($node->uses as $use) {
+            $fqcn = $use->name->toString();
+
+            if (preg_match($this->operationClassPattern, $fqcn) === 1 && ! isset($this->validFqcns[$fqcn])) {
+                return NodeVisitor::REMOVE_NODE;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/StaleImportRemoval/ControllerWithStaleImport.php
+++ b/tests/StaleImportRemoval/ControllerWithStaleImport.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d\GetViewerQuery;
+
+final readonly class ControllerWithStaleImport
+{
+    private const string OPERATION = <<<'GRAPHQL'
+        query GetViewer {
+            viewer {
+                login
+            }
+        }
+        GRAPHQL;
+
+    public function __construct(
+        #[GeneratedGraphQLClient(self::OPERATION)]
+        public GetViewerQuery $query,
+    ) {}
+}

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d;
+
+use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data/Viewer.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data/Viewer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Error.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/GetViewerQuery.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/GetViewerQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class GetViewerQuery {
+    public const string OPERATION_NAME = 'GetViewer';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query GetViewer {
+          viewer {
+            login
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/StaleImportRemoval/Schema.graphql
+++ b/tests/StaleImportRemoval/Schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+}

--- a/tests/StaleImportRemoval/StaleImportRemovalTest.php
+++ b/tests/StaleImportRemoval/StaleImportRemovalTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\Executor\PlanExecutor;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\Planner;
+
+final class StaleImportRemovalTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withInlineProcessingDirectory(__DIR__);
+    }
+
+    public function testStaleImportsAreRemoved() : void
+    {
+        // First, create a "stale" version of the controller file with old imports
+        $staleContent = <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval;
+
+            use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+            use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewerabc123\GetViewerQuery;
+            use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewerdef456\GetViewerQuery as AliasedQuery;
+
+            final readonly class ControllerWithStaleImport
+            {
+                private const string OPERATION = <<<'GRAPHQL'
+                    query GetViewer {
+                        viewer {
+                            login
+                        }
+                    }
+                    GRAPHQL;
+
+                public function __construct(
+                    #[GeneratedGraphQLClient(self::OPERATION)]
+                    public GetViewerQuery $query,
+                ) {}
+            }
+            PHP;
+
+        $controllerPath = __DIR__ . '/ControllerWithStaleImport.php';
+        $originalContent = file_get_contents($controllerPath);
+
+        try {
+            // Write the stale content
+            file_put_contents($controllerPath, $staleContent);
+
+            // Run the generator
+            $config = $this->getConfig();
+            $plan = new Planner($config)->plan();
+            $files = new PlanExecutor($config)->execute($plan);
+
+            // Check the output
+            self::assertArrayHasKey($controllerPath, $files, 'Controller file should be in output');
+            $output = $files[$controllerPath];
+
+            // The stale imports should be removed
+            self::assertStringNotContainsString(
+                'GetViewerabc123',
+                $output,
+                'Stale import with old hash should be removed',
+            );
+            self::assertStringNotContainsString(
+                'GetViewerdef456',
+                $output,
+                'Another stale import should also be removed',
+            );
+
+            // The correct import should be present
+            $matches = [];
+            preg_match_all(
+                '/use Ruudk\\\\GraphQLCodeGenerator\\\\StaleImportRemoval\\\\Generated\\\\Query\\\\GetViewer[a-f0-9]+\\\\GetViewerQuery/',
+                $output,
+                $matches,
+            );
+
+            self::assertCount(
+                1,
+                $matches[0],
+                'There should be exactly one import for GetViewerQuery with the correct hash',
+            );
+        } finally {
+            // Restore the original content
+            file_put_contents($controllerPath, $originalContent);
+        }
+    }
+}

--- a/tests/StaleImportRemoval/StaleImportRemoverTest.php
+++ b/tests/StaleImportRemoval/StaleImportRemoverTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval;
+
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
+use Ruudk\GraphQLCodeGenerator\PHP\Visitor\StaleImportRemover;
+
+final class StaleImportRemoverTest extends TestCase
+{
+    public function testPatternMatching() : void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            namespace App;
+
+            use App\Generated\Query\GetViewerabc123\GetViewerQuery;
+            use App\Generated\Query\GetViewerdef456\GetViewerQuery as AliasedQuery;
+            use App\Generated\Mutation\CreateUser123abc\CreateUserMutation;
+            use SomeOther\Class\NotGenerated;
+
+            class Foo {}
+            PHP;
+
+        $parser = new ParserFactory()->createForNewestSupportedVersion();
+        $stmts = $parser->parse($code);
+
+        self::assertNotNull($stmts);
+
+        $remover = new StaleImportRemover(
+            'App\Generated',
+            ['App\Generated\Query\GetViewer6b9a6d\GetViewerQuery'], // Only this one is valid
+        );
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($remover);
+        $newStmts = $traverser->traverse($stmts);
+
+        $printer = new Standard();
+        $output = $printer->prettyPrintFile($newStmts);
+
+        // The valid import should be... wait, it's not in the original code
+        // Let me check what happens to stale imports
+        self::assertStringNotContainsString('GetViewerabc123', $output, 'Stale abc123 should be removed');
+        self::assertStringNotContainsString('GetViewerdef456', $output, 'Stale def456 should be removed');
+        self::assertStringNotContainsString('CreateUser123abc', $output, 'Stale mutation should be removed');
+        self::assertStringContainsString('SomeOther\Class\NotGenerated', $output, 'Non-generated import should remain');
+    }
+
+    public function testRegexPatternDirectly() : void
+    {
+        $namespace = 'App\Generated';
+        $escapedNamespace = preg_quote($namespace, '/');
+        $pattern = '/^' . $escapedNamespace . '\\\\(?:Query|Mutation)\\\\[A-Za-z]+[a-f0-9]{6}\\\\/';
+
+        // Should match stale imports
+        self::assertSame(1, preg_match($pattern, 'App\Generated\Query\GetViewerabc123\GetViewerQuery'));
+        self::assertSame(1, preg_match($pattern, 'App\Generated\Query\GetViewer6b9a6d\GetViewerQuery'));
+        self::assertSame(1, preg_match($pattern, 'App\Generated\Mutation\CreateUser123abc\CreateUserMutation'));
+
+        // Should NOT match non-generated imports
+        self::assertSame(0, preg_match($pattern, 'SomeOther\Class\NotGenerated'));
+        self::assertSame(0, preg_match($pattern, 'App\Generated\Enum\SomeEnum'));
+    }
+
+    public function testExactIntegrationScenario() : void
+    {
+        // This matches the exact scenario from the integration test
+        $namespace = 'Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated';
+        $escapedNamespace = preg_quote($namespace, '/');
+        $pattern = '/^' . $escapedNamespace . '\\\\(?:Query|Mutation)\\\\[A-Za-z]+[a-f0-9]{6}\\\\/';
+
+        // The stale import
+        $stale = 'Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewerabc123\GetViewerQuery';
+
+        // The correct import
+        $correct = 'Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d\GetViewerQuery';
+
+        self::assertSame(1, preg_match($pattern, $stale), 'Stale import should match pattern');
+        self::assertSame(1, preg_match($pattern, $correct), 'Correct import should match pattern');
+    }
+
+    public function testKeepsSiblingClassesUnderValidOperationNamespace() : void
+    {
+        // Reproduces a bug seen in cosmos: when a Query's import is valid, sibling
+        // classes under the SAME operation namespace (e.g. FailedException, Data)
+        // must also be kept — they belong to the same generated operation and the
+        // caller has a legitimate reason to use them (catch blocks, type hints, etc.).
+        $code = <<<'PHP'
+            <?php
+
+            namespace App;
+
+            use App\Generated\Query\GetViewer6b9a6d\Data\Viewer;
+            use App\Generated\Query\GetViewer6b9a6d\GetViewerQuery;
+            use App\Generated\Query\GetViewer6b9a6d\GetViewerQueryFailedException;
+
+            final class Controller
+            {
+                public function __construct(
+                    private readonly GetViewerQuery $query,
+                ) {}
+
+                public function run() : Viewer
+                {
+                    try {
+                        return $this->query->executeOrThrow()->viewer;
+                    } catch (GetViewerQueryFailedException) {
+                        throw new \RuntimeException();
+                    }
+                }
+            }
+            PHP;
+
+        $parser = new ParserFactory()->createForNewestSupportedVersion();
+        $stmts = $parser->parse($code);
+
+        self::assertNotNull($stmts);
+
+        $remover = new StaleImportRemover(
+            'App\Generated',
+            ['App\Generated\Query\GetViewer6b9a6d\GetViewerQuery'],
+        );
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($remover);
+        $newStmts = $traverser->traverse($stmts);
+
+        $output = new Standard()->prettyPrintFile($newStmts);
+
+        self::assertStringContainsString('GetViewerQuery;', $output, 'The valid Query import must remain');
+        self::assertStringContainsString(
+            'GetViewerQueryFailedException',
+            $output,
+            'FailedException under the same valid operation namespace must not be removed',
+        );
+        self::assertStringContainsString(
+            'Data\\Viewer',
+            $output,
+            'Data sibling classes under the same valid operation namespace must not be removed',
+        );
+    }
+
+    public function testRemovalWithMultipleVisitors() : void
+    {
+        // Simulate what happens in PlanExecutor
+        $code = <<<'PHP'
+            <?php
+
+            namespace Ruudk\GraphQLCodeGenerator\StaleImportRemoval;
+
+            use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+            use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewerabc123\GetViewerQuery;
+            use Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewerdef456\GetViewerQuery as AliasedQuery;
+
+            final readonly class ControllerWithStaleImport {}
+            PHP;
+
+        $parser = new ParserFactory()->createForNewestSupportedVersion();
+        $stmts = $parser->parse($code);
+
+        self::assertNotNull($stmts);
+
+        $fqcns = ['Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated\Query\GetViewer6b9a6d\GetViewerQuery'];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new \PhpParser\NodeVisitor\NodeConnectingVisitor());
+        $traverser->addVisitor(new StaleImportRemover('Ruudk\GraphQLCodeGenerator\StaleImportRemoval\Generated', $fqcns));
+        $traverser->addVisitor(new \Ruudk\GraphQLCodeGenerator\PHP\Visitor\UseStatementInserter($fqcns));
+        $newStmts = $traverser->traverse($stmts);
+
+        $printer = new Standard();
+        $output = $printer->prettyPrintFile($newStmts);
+
+        self::assertStringNotContainsString('GetViewerabc123', $output, 'Stale abc123 should be removed');
+        self::assertStringNotContainsString('GetViewerdef456', $output, 'Stale def456 should be removed');
+        self::assertStringContainsString('GetViewer6b9a6d', $output, 'Correct import should be present');
+    }
+}


### PR DESCRIPTION
This PR improves code maintenance by automatically removing stale generated imports and enhances the developer experience by showing diffs when `--ensure-sync` detects mismatches, making it easier to understand and fix synchronization issues.

### Introduce stale generated import removal

When a file is moved or refactored, the hash in generated import paths changes. Previously the generator would add the new correct import but leave the old stale import behind, forcing manual cleanup and leaving CI in a bad state.

This re-introduces `StaleImportRemover` (reverted in #35) with a fix for the regression that caused the original rollback: it now only removes imports whose leaf class is the operation's own `Query`, `Mutation`, or matching `FailedException`. Sibling classes under the same operation namespace (`Data\...`, `Error\...`) are left untouched because the remover has no way to tell whether they are still in use.

`PlanExecutor` also now collects the full set of valid operation FQCNs across the entire plan — not just the ones injected into the current file — so an `@throws SomeQueryFailedException` in a file that does not itself use the query is preserved as long as the hash still points to a planned operation.

### Show diff on --ensure-sync mismatch

When `--ensure-sync` detected drift between generated and on-disk files, it only printed `<path> content does not match expectations`. In practice you still had to run the generator locally to understand what actually changed — CI logs were useless for diagnosing why a file was out of sync.

Render a colorized unified diff (red/green, `@@` hunks) for every mismatched file so the CI log alone makes the cause obvious. Uses `sebastian/diff`, which is already available transitively via PHPUnit; promoted to a direct runtime dependency.
