### PR TITLE
Add @hook directive for locally resolved lazy properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ enum SearchType: string
 - **Lazy-loading** for nested objects (only instantiated when accessed)
 - **Connection pattern awareness** (edges, nodes, pageInfo) for Relay-style APIs
 - **Custom `@indexBy` directive** for O(1) lookups instead of O(n) searching
+- **Custom `@hook` directive** - enrich responses with local data resolved lazily at access time
 - **Fragment dependency injection** - automatically includes required fragments
 - **Automatic query optimization** - merges fragments, simplifies inline fragments
 
@@ -607,6 +608,96 @@ final class Data
     }
 }
 ```
+
+### 🪝 Local Resolution with `@hook` Directive
+
+Enrich query results with data that does not come from the GraphQL server.
+Common case: the backend returns an ID, and you want the generated response to also expose the
+fully hydrated local entity (from your database, cache, etc.) lazily on first access.
+
+**Step 1 — write an invokable hook class** and tag it with `#[Hook(name: ...)]`:
+
+```php
+namespace App\Hooks;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    public function __construct(private UserRepository $users) {}
+
+    public function __invoke(string $id): ?User
+    {
+        return $this->users->find($id);
+    }
+}
+```
+
+The class must define `__invoke`. The return type is inferred from that signature — no need to
+declare it in config.
+
+**Step 2 — register the hook** in your config:
+
+```php
+Config::create(/* ... */)
+    ->withHook(App\Hooks\FindUserByIdHook::class);
+```
+
+**Step 3 — use `@hook` in your query**:
+
+```graphql
+query Project {
+    project(id: "42") {
+        name
+        creator {
+            id
+        }
+
+        # Synthetic field populated by the hook. Positional arguments are
+        # resolved against the surrounding selection set.
+        user @hook(name: "findUserById", input: ["creator.id"])
+    }
+}
+```
+
+The `user` field doesn't exist in the schema — it's a generator-only marker. The `input` list
+holds dotted paths into the enclosing selection; each becomes a positional argument to
+`__invoke` at runtime.
+
+**Step 4 — pass hook instances when executing**:
+
+```php
+$project = new ProjectQuery($client, [
+    'findUserById' => new FindUserByIdHook($userRepository),
+])->execute()->project;
+
+$project->user; // ?User, resolved lazily by the hook on first access
+```
+
+The generator does not strip the `@hook` directive from validation inputs — it removes hook
+fields from the outgoing operation, so the server never sees them. Fragment spreads and `@indexBy`
+are unaffected.
+
+**Symfony autowire shortcut.** Call `enableSymfonyAutowireHooks()` on the config and the
+generated query class's `$hooks` parameter is annotated with `#[Autowire([...])]`, so the DI
+container wires the map automatically:
+
+```php
+// Generated ProjectQuery.php
+public function __construct(
+    private TestClient $client,
+    #[Autowire([
+        'findUserById' => new Autowire(FindUserByIdHook::class)
+    ])]
+    private array $hooks,
+) {}
+```
+
+Hook signature mismatches are caught at generation (return type inference) and by PHPStan at
+call sites — if you pass the wrong shape, CI fails before production.
 
 ## Requirements
 

--- a/src/Attribute/Hook.php
+++ b/src/Attribute/Hook.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Hook
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -6,8 +6,16 @@ namespace Ruudk\GraphQLCodeGenerator\Config;
 
 use Closure;
 use GraphQL\Type\Schema;
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Webmozart\Assert\Assert;
 
 final readonly class Config
 {
@@ -21,6 +29,7 @@ final readonly class Config
      * @param null|object|(Closure(): object) $introspectionClient
      * @param list<string> $inlineProcessingDirectories
      * @param list<string> $twigProcessingDirectories
+     * @param array<string, HookDefinition> $hooks
      */
     private function __construct(
         public Schema | string $schema,
@@ -50,6 +59,8 @@ final readonly class Config
         public array $inlineProcessingDirectories = [],
         public array $twigProcessingDirectories = [],
         public bool $formatOperationFiles = false,
+        public array $hooks = [],
+        public bool $symfonyAutowireHooks = false,
     ) {}
 
     public static function create(
@@ -154,6 +165,17 @@ final readonly class Config
         ]);
     }
 
+    /**
+     * Emit Symfony `#[Autowire([...])]` on the generated query class's `$hooks`
+     * constructor argument so the DI container can inject each hook service by class name.
+     */
+    public function enableSymfonyAutowireHooks() : self
+    {
+        return clone ($this, [
+            'symfonyAutowireHooks' => true,
+        ]);
+    }
+
     public function withScalar(string $name, Type $type, ?Type $payloadType = null) : self
     {
         $scalars = $this->scalars;
@@ -232,6 +254,58 @@ final readonly class Config
     {
         return clone ($this, [
             'twigProcessingDirectories' => array_merge($this->twigProcessingDirectories, [$directory], array_values($directories)),
+        ]);
+    }
+
+    /**
+     * Register a hook. The class must be invokable (`__invoke`) and must carry
+     * `#[Hook(name: '...')]` naming the hook for use in `@hook(name: ...)` directives.
+     * The return type is inferred from the `__invoke` signature.
+     *
+     * @param class-string $class
+     * @throws InvalidArgumentException
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function withHook(string $class) : self
+    {
+        Assert::classExists($class, sprintf('Hook class "%s" does not exist.', $class));
+        Assert::methodExists($class, '__invoke', sprintf('Hook class "%s" must be invokable (define __invoke).', $class));
+
+        $attributes = new ReflectionClass($class)->getAttributes(Hook::class);
+
+        Assert::notEmpty($attributes, sprintf(
+            'Hook class "%s" must carry a #[Hook(name: "...")] attribute.',
+            $class,
+        ));
+
+        $hookName = $attributes[0]->newInstance()->name;
+        $method = new ReflectionMethod($class, '__invoke');
+
+        Assert::keyNotExists($this->hooks, $hookName, sprintf(
+            'Hook "%s" is already registered (at %s).',
+            $hookName,
+            $this->hooks[$hookName]->class ?? '?',
+        ));
+
+        try {
+            $returnType = TypeResolver::create()->resolve($method);
+        } catch (UnsupportedException $exception) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Could not infer return type for hook "%s" from %s::__invoke(). Declare an explicit return type.',
+                    $hookName,
+                    $class,
+                ),
+                previous: $exception,
+            );
+        }
+
+        $hooks = $this->hooks;
+        $hooks[$hookName] = new HookDefinition($hookName, $class, $returnType);
+
+        return clone ($this, [
+            'hooks' => $hooks,
         ]);
     }
 }

--- a/src/Config/HookDefinition.php
+++ b/src/Config/HookDefinition.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Config;
+
+use Symfony\Component\TypeInfo\Type;
+
+final readonly class HookDefinition
+{
+    /**
+     * @param class-string $class
+     */
+    public function __construct(
+        public string $name,
+        public string $class,
+        public Type $returnType,
+    ) {}
+}

--- a/src/DirectiveProcessor.php
+++ b/src/DirectiveProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator;
 
 use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\StringValueNode;
 
@@ -42,5 +43,50 @@ final class DirectiveProcessor
         }
 
         return [];
+    }
+
+    /**
+     * Extract the @hook directive's `name` and `input` arguments.
+     *
+     * @param NodeList<DirectiveNode> $directives
+     * @return null|array{name: string, input: list<string>}
+     */
+    public function getHookDirective(NodeList $directives) : ?array
+    {
+        foreach ($directives as $directive) {
+            if ($directive->name->value !== 'hook') {
+                continue;
+            }
+
+            $name = null;
+            $input = [];
+
+            foreach ($directive->arguments as $argument) {
+                if ($argument->name->value === 'name' && $argument->value instanceof StringValueNode) {
+                    $name = $argument->value->value;
+
+                    continue;
+                }
+
+                if ($argument->name->value === 'input' && $argument->value instanceof ListValueNode) {
+                    foreach ($argument->value->values as $value) {
+                        if ($value instanceof StringValueNode) {
+                            $input[] = $value->value;
+                        }
+                    }
+                }
+            }
+
+            if ($name === null) {
+                continue;
+            }
+
+            return [
+                'name' => $name,
+                'input' => $input,
+            ];
+        }
+
+        return null;
     }
 }

--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -34,6 +34,7 @@ use Ruudk\GraphQLCodeGenerator\Planner\Plan\InputClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\NodeNotFoundExceptionPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\BackedEnumTypeInitializer;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer\ClassHookUsageRegistry;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\CollectionTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\IndexByCollectionTypeInitializer;
@@ -53,26 +54,29 @@ final class PlanExecutor
     private readonly ExceptionClassGenerator $exceptionClassGenerator;
     private readonly InputTypeGenerator $inputTypeGenerator;
     private readonly NodeNotFoundExceptionGenerator $nodeNotFoundExceptionGenerator;
+    private readonly ClassHookUsageRegistry $hookUsageRegistry;
     private Parser $phpParser;
     private Filesystem $filesystem;
 
     public function __construct(
         private Config $config,
     ) {
+        $this->hookUsageRegistry = new ClassHookUsageRegistry();
+
         // Initialize type initializer
         $typeInitializer = new DelegatingTypeInitializer(
             new NullableTypeInitializer(),
             new IndexByCollectionTypeInitializer(),
             new CollectionTypeInitializer(),
             new BackedEnumTypeInitializer($config->addUnknownCaseToEnums, $config->namespace),
-            new ObjectTypeInitializer(),
+            new ObjectTypeInitializer()->setHookUsageRegistry($this->hookUsageRegistry),
             ...$config->typeInitializers,
         );
 
         // Initialize all generators
         $this->dataClassGenerator = new DataClassGenerator($config, $typeInitializer);
         $this->enumTypeGenerator = new EnumTypeGenerator($config);
-        $this->operationClassGenerator = new OperationClassGenerator($config);
+        $this->operationClassGenerator = new OperationClassGenerator($config, $this->hookUsageRegistry);
         $this->errorClassGenerator = new ErrorClassGenerator($config);
         $this->exceptionClassGenerator = new ExceptionClassGenerator($config);
         $this->inputTypeGenerator = new InputTypeGenerator($config);
@@ -91,6 +95,14 @@ final class PlanExecutor
      */
     public function execute(PlannerResult $plan) : array
     {
+        $this->hookUsageRegistry->classHooks = [];
+
+        foreach ($plan->classes as $class) {
+            if ($class instanceof DataClassPlan && $class->usedHooks !== []) {
+                $this->hookUsageRegistry->classHooks[$class->fqcn] = $class->usedHooks;
+            }
+        }
+
         $files = [];
 
         foreach ($plan->classes as $path => $class) {

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\Generator;
 
 use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\ScalarType;
 use Symfony\Component\TypeInfo\Type;
+use Webmozart\Assert\Assert;
 
 abstract class AbstractGenerator
 {
@@ -33,6 +35,10 @@ abstract class AbstractGenerator
      */
     protected function dumpPHPType(Type $type, callable $importer) : string
     {
+        if ($type instanceof HookPropertyType) {
+            return $this->dumpPHPType($type->getWrappedType(), $importer);
+        }
+
         if ($type instanceof Type\NullableType) {
             $wrappedType = $type->getWrappedType();
 
@@ -77,5 +83,28 @@ abstract class AbstractGenerator
         }
 
         return $type;
+    }
+
+    /**
+     * Build the PHPDoc `array{hookName: HookClass, ...}` shape used to annotate
+     * the `$hooks` constructor argument threaded through generated classes.
+     *
+     * @param array<string, true> $usedHooks
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     */
+    protected function buildHooksShape(array $usedHooks) : Type
+    {
+        $shape = [];
+
+        foreach (array_keys($usedHooks) as $name) {
+            Assert::keyExists(
+                $this->config->hooks,
+                $name,
+                sprintf('Hook "%s" is not registered in config.', $name),
+            );
+            $shape[$name] = Type::object($this->config->hooks[$name]->class);
+        }
+
+        return Type::arrayShape($shape);
     }
 }

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -15,6 +15,7 @@ use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
+use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
 use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
@@ -115,7 +116,7 @@ final class DataClassGenerator extends AbstractGenerator
             $requiredFieldsMap = $inlineFragmentRequiredFields;
 
             yield $generator->indent(
-                function () use ($parentType, $nodesType, $possibleTypes, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap) {
+                function () use ($plan, $parentType, $nodesType, $possibleTypes, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap) {
                     if ($possibleTypes !== []) {
                         yield from $generator->docComment('@var list<string>');
                         yield sprintf(
@@ -158,6 +159,44 @@ final class DataClassGenerator extends AbstractGenerator
                             $nakedFieldType = $this->getNakedType($fieldType);
 
                             yield '';
+
+                            // Hook-backed synthetic property: not stored in $this->data, resolved
+                            // at access time by invoking the user-supplied hook (an invokable
+                            // class) with positional arguments in the order declared by the
+                            // directive.
+                            if ($fieldType instanceof HookPropertyType) {
+                                yield sprintf(
+                                    'public %s $%s {',
+                                    $this->dumpPHPType($fieldType, $generator->import(...)),
+                                    $fieldName,
+                                );
+                                yield $generator->indent(function () use ($fieldType, $fieldName, $generator) {
+                                    $args = [];
+
+                                    foreach ($fieldType->inputPaths as $path) {
+                                        $accessor = '$this->data';
+
+                                        foreach (explode('.', $path) as $segment) {
+                                            $accessor .= '[' . var_export($segment, true) . ']';
+                                        }
+
+                                        $args[] = $accessor;
+                                    }
+
+                                    yield from $generator->wrap(
+                                        sprintf('get => $this->%s ??= ', $fieldName),
+                                        $generator->dumpCall(
+                                            sprintf('$this->hooks[%s]', var_export($fieldType->hookName, true)),
+                                            '__invoke',
+                                            $args,
+                                        ),
+                                        ';',
+                                    );
+                                });
+                                yield '}';
+
+                                continue;
+                            }
 
                             // Check the payload shape to properly handle nullability
                             $payloadType = $payloadFieldTypes[$fieldName] ?? null;
@@ -480,8 +519,10 @@ final class DataClassGenerator extends AbstractGenerator
                         yield 'public readonly array $errors;';
                     }
 
+                    $usesHooks = $plan->usedHooks !== [];
+
                     yield '';
-                    yield from $generator->docComment(function () use ($isData, $generator, $payloadShape) {
+                    yield from $generator->docComment(function () use ($plan, $isData, $usesHooks, $generator, $payloadShape) {
                         yield sprintf(
                             '@param %s $data',
                             TypeDumper::dump($payloadShape, $generator->import(...)),
@@ -500,9 +541,16 @@ final class DataClassGenerator extends AbstractGenerator
                                 ])), $generator->import(...)),
                             );
                         }
+
+                        if ($usesHooks) {
+                            yield sprintf(
+                                '@param %s $hooks',
+                                TypeDumper::dump($this->buildHooksShape($plan->usedHooks), $generator->import(...)),
+                            );
+                        }
                     });
                     yield 'public function __construct(';
-                    yield $generator->indent(function () use ($generator, $payloadShape, $isData) {
+                    yield $generator->indent(function () use ($generator, $payloadShape, $isData, $usesHooks) {
                         yield sprintf(
                             'private readonly %s $data,',
                             $this->dumpPHPType($payloadShape, $generator->import(...)),
@@ -510,6 +558,10 @@ final class DataClassGenerator extends AbstractGenerator
 
                         if ($isData) {
                             yield 'array $errors,';
+                        }
+
+                        if ($usesHooks) {
+                            yield 'private readonly array $hooks,';
                         }
                     });
 

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -7,14 +7,23 @@ namespace Ruudk\GraphQLCodeGenerator\Generator;
 use JsonException;
 use Ruudk\CodeGenerator\CodeGenerator;
 use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\OperationClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer\ClassHookUsageRegistry;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
 final class OperationClassGenerator extends AbstractGenerator
 {
+    public function __construct(
+        Config $config,
+        private readonly ClassHookUsageRegistry $hookUsageRegistry,
+    ) {
+        parent::__construct($config);
+    }
+
     /**
      * @throws JsonException
      */
@@ -27,9 +36,12 @@ final class OperationClassGenerator extends AbstractGenerator
             $plan->operationName . $plan->operationType . 'FailedException',
         );
 
+        $dataFqcn = $namespace . '\\Data';
+        $usedHooks = $this->hookUsageRegistry->getHooksForClass($dataFqcn);
+
         $generator = new CodeGenerator($namespace);
 
-        return $generator->dumpFile(function () use ($generator, $plan, $namespace, $failedException) {
+        return $generator->dumpFile(function () use ($generator, $plan, $namespace, $failedException, $usedHooks) {
             yield $this->dumpHeader();
 
             yield '';
@@ -49,7 +61,7 @@ final class OperationClassGenerator extends AbstractGenerator
 
             yield sprintf('final readonly class %s {', $plan->className);
             yield $generator->indent(
-                function () use ($plan, $failedException, $namespace, $generator) {
+                function () use ($plan, $failedException, $namespace, $generator, $usedHooks) {
                     yield sprintf('public const string OPERATION_NAME = %s;', var_export($plan->operationName, true));
                     yield sprintf(
                         'public const string OPERATION_DEFINITION = %s;',
@@ -57,10 +69,45 @@ final class OperationClassGenerator extends AbstractGenerator
                     );
 
                     yield '';
+
+                    if ($usedHooks !== []) {
+                        yield from $generator->docComment(function () use ($usedHooks, $generator) {
+                            yield sprintf(
+                                '@param %s $hooks',
+                                TypeDumper::dump($this->buildHooksShape($usedHooks), $generator->import(...)),
+                            );
+                        });
+                    }
+
                     yield 'public function __construct(';
-                    yield $generator->indent([
-                        sprintf('private %s $client,', $generator->import($this->config->client)),
-                    ]);
+                    yield $generator->indent(function () use ($generator, $usedHooks) {
+                        yield sprintf('private %s $client,', $generator->import($this->config->client));
+
+                        if ($usedHooks === []) {
+                            return;
+                        }
+
+                        if ($this->config->symfonyAutowireHooks) {
+                            $autowire = $generator->import('Symfony\Component\DependencyInjection\Attribute\Autowire');
+                            yield sprintf('#[%s([', $autowire);
+                            yield $generator->indent(function () use ($usedHooks, $autowire, $generator) {
+                                $lines = [];
+                                foreach (array_keys($usedHooks) as $name) {
+                                    $lines[] = sprintf(
+                                        '%s => new %s(service: %s::class)',
+                                        var_export($name, true),
+                                        $autowire,
+                                        $generator->import($this->config->hooks[$name]->class),
+                                    );
+                                }
+
+                                yield implode(",\n", $lines);
+                            });
+                            yield '])]';
+                        }
+
+                        yield 'private array $hooks,';
+                    });
                     yield ') {}';
 
                     $parameters = $generator->indent(function () use ($plan, $generator) {
@@ -104,7 +151,7 @@ final class OperationClassGenerator extends AbstractGenerator
                         yield '{';
                     }
 
-                    yield $generator->indent(function () use ($plan, $generator) {
+                    yield $generator->indent(function () use ($plan, $generator, $usedHooks) {
                         yield '$data = $this->client->graphql(';
                         yield $generator->indent(function () use ($plan, $generator) {
                             yield 'self::OPERATION_DEFINITION,';
@@ -141,10 +188,18 @@ final class OperationClassGenerator extends AbstractGenerator
                         yield ');';
                         yield '';
                         yield 'return new Data(';
-                        yield $generator->indent([
-                            "\$data['data'] ?? [], // @phpstan-ignore argument.type",
-                            "\$data['errors'] ?? [] // @phpstan-ignore argument.type",
-                        ]);
+                        $trailingComma = $usedHooks !== [] ? ',' : '';
+                        yield $generator->indent(function () use ($trailingComma, $usedHooks) {
+                            yield "\$data['data'] ?? [], // @phpstan-ignore argument.type";
+                            yield sprintf(
+                                "\$data['errors'] ?? []%s // @phpstan-ignore argument.type",
+                                $trailingComma,
+                            );
+
+                            if ($usedHooks !== []) {
+                                yield '$this->hooks,';
+                            }
+                        });
                         yield ');';
                     });
                     yield '}';

--- a/src/GraphQL/HookDirectiveSchemaExtender.php
+++ b/src/GraphQL/HookDirectiveSchemaExtender.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\SchemaExtender;
+use InvalidArgumentException;
+use JsonException;
+use Webmozart\Assert\Assert;
+
+final readonly class HookDirectiveSchemaExtender
+{
+    /**
+     * Extends schema with @hook directive. If @hook already exists, it verifies that it's correct.
+     *
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     * @throws InvariantViolation
+     * @throws Exception
+     */
+    public static function extend(Schema $schema) : Schema
+    {
+        $existing = $schema->getDirective('hook');
+
+        if ($existing !== null) {
+            Assert::eq($existing->locations, ['FIELD'], 'Expected @hook to be on FIELD');
+            Assert::count($existing->args, 2, 'Expected @hook to have 2 arguments');
+
+            [$name, $input] = $existing->args;
+            Assert::eq($name->name, 'name', 'Expected @hook first argument to be named "name"');
+            Assert::eq(Type::nonNull(Type::string()), $name->getType(), 'Expected @hook "name" argument to be a non-null string');
+            Assert::eq($input->name, 'input', 'Expected @hook second argument to be named "input"');
+            Assert::eq(Type::nonNull(Type::listOf(Type::nonNull(Type::string()))), $input->getType(), 'Expected @hook "input" argument to be a non-null list of non-null strings');
+
+            return $schema;
+        }
+
+        return SchemaExtender::extend(
+            $schema,
+            Parser::parse(
+                <<<'GRAPHQL'
+                    directive @hook(name: String!, input: [String!]!) on FIELD
+                    GRAPHQL,
+            ),
+        );
+    }
+}

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -81,9 +81,11 @@ use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLExtension;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLNodeFinder;
+use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\TypeHelper;
 use Ruudk\GraphQLCodeGenerator\Validator\IndexByValidator;
 use Ruudk\GraphQLCodeGenerator\Visitor\DefinedFragmentsVisitor;
+use Ruudk\GraphQLCodeGenerator\Visitor\HookFieldRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\IndexByRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\UsedFragmentsVisitor;
 use Stringable;
@@ -160,7 +162,7 @@ final class Planner
         ];
 
         $this->schemaLoader = new SchemaLoader(new Filesystem());
-        $this->schema = $this->schemaLoader->load($config->schema, $config->indexByDirective);
+        $this->schema = $this->schemaLoader->load($config->schema, $config->indexByDirective, $config->hooks !== []);
         $this->optimizer = new Optimizer($this->schema);
         $this->possibleTypesFinder = new PossibleTypesFinder($this->schema);
 
@@ -502,9 +504,15 @@ final class Planner
          */
         $fragmentsToProcess = [];
         foreach (array_reverse($ordered) as $fragment) {
-            $errors = DocumentValidator::validate($this->schema, new DocumentNode([
+            $validationDocument = new DocumentNode([
                 'definitions' => new NodeList([$fragment]),
-            ]), $this->validatorRules);
+            ]);
+
+            if ($this->config->hooks !== []) {
+                $validationDocument = new HookFieldRemover()->__invoke($validationDocument);
+            }
+
+            $errors = DocumentValidator::validate($this->schema, $validationDocument, $this->validatorRules);
 
             if ($errors !== []) {
                 throw new Exception(sprintf('Fragment validation failed: %s', implode(PHP_EOL, array_map(fn($error) => $error->getMessage(), $errors))));
@@ -579,7 +587,126 @@ final class Planner
 
         $result->setOperationsToInject($operationsToInject);
 
+        if ($this->config->hooks !== []) {
+            $this->propagateUsedHooks($result);
+        }
+
         return $result;
+    }
+
+    /**
+     * Populate `usedHooks` on every DataClassPlan: each plan's own hook fields union the
+     * `usedHooks` sets of every child DataClassPlan it constructs (transitively).
+     *
+     * Iterates to a fixed point instead of topologically sorting — planner-emitted class
+     * graphs are small and may contain back-references via fragments, which makes a fixed
+     * point simpler than computing a correct order.
+     */
+    private function propagateUsedHooks(PlannerResult $result) : void
+    {
+        /**
+         * @var array<string, DataClassPlan> $plansByFqcn
+         */
+        $plansByFqcn = [];
+        /**
+         * @var array<string, list<string>> $childFqcnsByPlan
+         */
+        $childFqcnsByPlan = [];
+
+        foreach ($result->classes as $plan) {
+            if ( ! $plan instanceof DataClassPlan) {
+                continue;
+            }
+
+            $plansByFqcn[$plan->fqcn] = $plan;
+            $plan->usedHooks = [];
+            $childFqcnsByPlan[$plan->fqcn] = [];
+
+            foreach ($this->fieldTypesIn($plan->fields) as $fieldType) {
+                if ($fieldType instanceof HookPropertyType) {
+                    $plan->usedHooks[$fieldType->hookName] = true;
+
+                    continue;
+                }
+
+                $nakedObject = $this->unwrapToObjectType($fieldType);
+
+                if ($nakedObject !== null) {
+                    $childFqcnsByPlan[$plan->fqcn][] = $nakedObject;
+                }
+            }
+        }
+
+        $changed = true;
+        while ($changed) {
+            $changed = false;
+
+            foreach ($plansByFqcn as $plan) {
+                $before = $plan->usedHooks;
+
+                foreach ($childFqcnsByPlan[$plan->fqcn] as $childFqcn) {
+                    $child = $plansByFqcn[$childFqcn] ?? null;
+
+                    if ($child === null) {
+                        continue;
+                    }
+
+                    foreach ($child->usedHooks as $hookName => $_) {
+                        $plan->usedHooks[$hookName] = true;
+                    }
+                }
+
+                if ($plan->usedHooks !== $before) {
+                    $changed = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * Yield each field's type from a class's fields shape (after unwrapping any
+     * outer nullable wrappers).
+     *
+     * @return iterable<SymfonyType>
+     */
+    private function fieldTypesIn(SymfonyType $type) : iterable
+    {
+        while ($type instanceof SymfonyType\NullableType) {
+            $type = $type->getWrappedType();
+        }
+
+        if ( ! $type instanceof SymfonyType\ArrayShapeType) {
+            return;
+        }
+
+        foreach ($type->getShape() as $entry) {
+            yield $entry['type'];
+        }
+    }
+
+    /**
+     * Peel off nullable/collection wrappers; return the FQCN of the nested ObjectType
+     * if that's what we find, otherwise null.
+     */
+    private function unwrapToObjectType(SymfonyType $type) : ?string
+    {
+        while (true) {
+            if ($type instanceof SymfonyType\NullableType) {
+                $type = $type->getWrappedType();
+
+                continue;
+            }
+
+            if ($type instanceof SymfonyType\CollectionType) {
+                $type = $type->getCollectionValueType();
+
+                continue;
+            }
+
+            break;
+        }
+
+        return $type instanceof SymfonyType\ObjectType ? $type->getClassName() : null;
     }
 
     /**
@@ -592,7 +719,13 @@ final class Planner
     {
         $document = $this->optimizer->optimize($document, $planner->fragmentDefinitions);
 
-        $errors = DocumentValidator::validate($this->schema, $document, $this->validatorRules);
+        $validationDocument = $document;
+
+        if ($this->config->hooks !== []) {
+            $validationDocument = new HookFieldRemover()->__invoke($validationDocument);
+        }
+
+        $errors = DocumentValidator::validate($this->schema, $validationDocument, $this->validatorRules);
 
         if ($errors !== []) {
             throw new Exception(sprintf(
@@ -637,6 +770,10 @@ final class Planner
 
         if ($this->config->indexByDirective) {
             $document = new IndexByRemover()->__invoke($document);
+        }
+
+        if ($this->config->hooks !== []) {
+            $document = new HookFieldRemover()->__invoke($document);
         }
 
         $operationDefinition = Printer::doPrint($document);

--- a/src/Planner/PayloadShapeBuilder.php
+++ b/src/Planner/PayloadShapeBuilder.php
@@ -141,6 +141,10 @@ final readonly class PayloadShapeBuilder
         // First pass: collect all direct field selections
         foreach ($selectionSet->selections as $selection) {
             if ($selection instanceof FieldNode) {
+                if ($this->hasHookDirective($selection)) {
+                    continue;
+                }
+
                 $fieldName = $selection->alias->value ?? $selection->name->value;
                 $fieldGroups[$fieldName] ??= [];
                 $fieldGroups[$fieldName][] = $selection;
@@ -454,6 +458,17 @@ final readonly class PayloadShapeBuilder
             $name = $directive->name->value;
 
             if ($name === 'include' || $name === 'skip') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasHookDirective(FieldNode $node) : bool
+    {
+        foreach ($node->directives as $directive) {
+            if ($directive->name->value === 'hook') {
                 return true;
             }
         }

--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -14,24 +14,32 @@ use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 
-final readonly class DataClassPlan
+final class DataClassPlan
 {
+    /**
+     * Set of hook names this class transitively needs. Populated by the planner.
+     * Empty means this class does not accept a `$hooks` constructor argument.
+     *
+     * @var array<string, true>
+     */
+    public array $usedHooks = [];
+
     /**
      * @param list<string> $possibleTypes
      * @param array<string, list<string>> $inlineFragmentRequiredFields
      */
     public function __construct(
-        public GraphQLFileSource | InlineSource | TwigFileSource $source,
-        public string $path,
-        public string $fqcn,
-        public NamedType & Type $parentType,
-        public SymfonyType $fields,
-        public SymfonyType $payloadShape,
-        public array $possibleTypes,
-        public null | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode $definitionNode,
-        public ?SymfonyType $nodesType,
-        public array $inlineFragmentRequiredFields,
-        public bool $isData,
-        public bool $isFragment,
+        public readonly GraphQLFileSource | InlineSource | TwigFileSource $source,
+        public readonly string $path,
+        public readonly string $fqcn,
+        public readonly NamedType & Type $parentType,
+        public readonly SymfonyType $fields,
+        public readonly SymfonyType $payloadShape,
+        public readonly array $possibleTypes,
+        public readonly null | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode $definitionNode,
+        public readonly ?SymfonyType $nodesType,
+        public readonly array $inlineFragmentRequiredFields,
+        public readonly bool $isData,
+        public readonly bool $isFragment,
     ) {}
 }

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -35,6 +35,7 @@ use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\RecursiveTypeFinder;
 use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
+use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
 use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
@@ -334,6 +335,28 @@ final class SelectionSetPlanner
         PayloadShape $payloadShape,
     ) : void {
         $fieldName = $selection->alias->value ?? $selection->name->value;
+
+        // Hook fields are synthetic — they don't exist in the schema and their value comes from
+        // a user-supplied callable at runtime rather than from the server response.
+        $hookDirective = $this->directiveProcessor->getHookDirective($selection->directives);
+
+        if ($hookDirective !== null) {
+            Assert::keyExists(
+                $this->config->hooks,
+                $hookDirective['name'],
+                sprintf('Hook "%s" used in selection is not registered via Config::withHook().', $hookDirective['name']),
+            );
+
+            $hook = $this->config->hooks[$hookDirective['name']];
+
+            $fields->add($fieldName, new HookPropertyType(
+                $hook->name,
+                $hookDirective['input'],
+                $hook->returnType,
+            ));
+
+            return;
+        }
 
         // Handle __typename specially
         if ($fieldName === '__typename') {

--- a/src/SchemaLoader.php
+++ b/src/SchemaLoader.php
@@ -28,7 +28,7 @@ final class SchemaLoader
      * @throws \Symfony\Component\Filesystem\Exception\IOException
      * @throws \Webmozart\Assert\InvalidArgumentException
      */
-    public function load(Schema | string $schema, bool $indexByDirective) : Schema
+    public function load(Schema | string $schema, bool $indexByDirective, bool $hookDirective) : Schema
     {
         if (is_string($schema) && str_ends_with($schema, '.graphql')) {
             $this->schemaPath = $schema;
@@ -49,6 +49,10 @@ final class SchemaLoader
 
         if ($indexByDirective) {
             $schema = GraphQL\IndexByDirectiveSchemaExtender::extend($schema);
+        }
+
+        if ($hookDirective) {
+            $schema = GraphQL\HookDirectiveSchemaExtender::extend($schema);
         }
 
         return $schema;

--- a/src/Type/HookPropertyType.php
+++ b/src/Type/HookPropertyType.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Type;
+
+use Override;
+use Symfony\Component\TypeInfo\Type as SymfonyType;
+use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+
+/**
+ * Marker type attached to a generated property that should be populated by a
+ * configured hook at runtime rather than by reading from `$this->data`.
+ *
+ * The wrapped type is the hook's declared return type (used both for the
+ * property's PHP type hint and for dumping any PHPDoc). The extra state
+ * (hook name + input paths) drives code emission in DataClassGenerator.
+ *
+ * This is a simple wrapper so that `instanceof HookPropertyType` is the only
+ * branch the generator has to add to iterate field types as usual.
+ *
+ * @implements WrappingTypeInterface<SymfonyType>
+ */
+final class HookPropertyType extends SymfonyType implements WrappingTypeInterface
+{
+    /**
+     * @param list<string> $inputPaths
+     */
+    public function __construct(
+        public readonly string $hookName,
+        public readonly array $inputPaths,
+        private readonly SymfonyType $returnType,
+    ) {}
+
+    #[Override]
+    public function getWrappedType() : SymfonyType
+    {
+        return $this->returnType;
+    }
+
+    #[Override]
+    public function wrappedTypeIsSatisfiedBy(callable $specification) : bool
+    {
+        return $specification($this->returnType);
+    }
+
+    #[Override]
+    public function __toString() : string
+    {
+        return (string) $this->returnType;
+    }
+}

--- a/src/TypeInitializer/ClassHookUsageRegistry.php
+++ b/src/TypeInitializer/ClassHookUsageRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\TypeInitializer;
+
+/**
+ * Knows which generated data classes accept a `$hooks` constructor argument
+ * and which hook names each one carries.
+ *
+ * Consulted by `ObjectTypeInitializer` (to forward `$this->hooks` into child
+ * constructors) and `OperationClassGenerator` (to emit the root query's
+ * hook parameter and shape). Populated once by `PlanExecutor` after planning.
+ */
+final class ClassHookUsageRegistry
+{
+    /**
+     * Keys are generated class FQCNs (stored as plain strings because they come
+     * from DataClassPlan::$fqcn, which is typed string).
+     *
+     * @var array<string, array<string, true>>
+     */
+    public array $classHooks = [];
+
+    public function usesHooks(string $fqcn) : bool
+    {
+        return isset($this->classHooks[$fqcn]);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    public function getHooksForClass(string $fqcn) : array
+    {
+        return $this->classHooks[$fqcn] ?? [];
+    }
+}

--- a/src/TypeInitializer/ObjectTypeInitializer.php
+++ b/src/TypeInitializer/ObjectTypeInitializer.php
@@ -19,11 +19,19 @@ final class ObjectTypeInitializer implements TypeInitializer
      * @var list<TypeInitializer>
      */
     private array $initializers;
+    private ?ClassHookUsageRegistry $hookUsageRegistry = null;
 
     public function __construct(
         TypeInitializer ...$initializers,
     ) {
         $this->initializers = array_values($initializers);
+    }
+
+    public function setHookUsageRegistry(ClassHookUsageRegistry $registry) : self
+    {
+        $this->hookUsageRegistry = $registry;
+
+        return $this;
     }
 
     #[Override]
@@ -47,6 +55,10 @@ final class ObjectTypeInitializer implements TypeInitializer
             return $initializer->initialize($type, $generator, $variable, $delegator);
         }
 
-        return sprintf('new %s(%s)', $generator->import($type->getClassName()), $variable);
+        $arguments = $this->hookUsageRegistry?->usesHooks($type->getClassName()) === true
+            ? sprintf('%s, $this->hooks', $variable)
+            : $variable;
+
+        return sprintf('new %s(%s)', $generator->import($type->getClassName()), $arguments);
     }
 }

--- a/src/Visitor/HookFieldRemover.php
+++ b/src/Visitor/HookFieldRemover.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Visitor;
+
+use Exception;
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorRemoveNode;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+final readonly class HookFieldRemover
+{
+    /**
+     * Removes fields that carry an `@hook` directive from the document entirely.
+     *
+     * The hook field name (e.g. `user`) is not a real field on the parent GraphQL type —
+     * it's a generator-only marker — so it must be stripped before schema validation and
+     * before the operation is printed for the server.
+     *
+     * @template T of Node
+     * @param T $node
+     *
+     * @throws InvalidArgumentException
+     * @throws Exception
+     * @return T
+     */
+    public function __invoke(Node $node) : Node
+    {
+        $new = Visitor::visit($node, [
+            NodeKind::FIELD => function (Node $node) : ?VisitorRemoveNode {
+                Assert::isInstanceOf($node, FieldNode::class);
+
+                foreach ($node->directives as $directive) {
+                    if ($directive->name->value === 'hook') {
+                        return Visitor::removeNode();
+                    }
+                }
+
+                return null;
+            },
+        ]);
+
+        Assert::isInstanceOf($new, Node::class);
+        Assert::isAOf($new, $node::class);
+
+        return $new;
+    }
+}

--- a/tests/Hooks/FindUserByIdHook.php
+++ b/tests/Hooks/FindUserByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    public function __invoke(string $id) : ?User
+    {
+        return $this->users[$id] ?? null;
+    }
+}

--- a/tests/Hooks/Generated/Query/Test/Data.php
+++ b/tests/Hooks/Generated/Query/Test/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer'], $this->hooks);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *         'projects': list<array{
+     *             'creator': array{
+     *                 'id': string,
+     *             },
+     *             'description': null|string,
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item, $this->hooks), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     *     'projects': list<array{
+     *         'creator': array{
+     *             'id': string,
+     *         },
+     *         'description': null|string,
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data\Viewer\Project\Creator;
+use Ruudk\GraphQLCodeGenerator\Hooks\User;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public Creator $creator {
+        get => $this->creator ??= new Creator($this->data['creator']);
+    }
+
+    public ?string $description {
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    public ?User $user {
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'description': null|string,
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Creator
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/Hooks/Generated/Query/Test/Error.php
+++ b/tests/Hooks/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/Hooks/Generated/Query/Test/TestQuery.php
+++ b/tests/Hooks/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            projects {
+              name
+              description
+              creator {
+                id
+              }
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/Hooks/HooksTest.php
+++ b/tests/Hooks/HooksTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\Hooks\Generated\Query\Test\TestQuery;
+
+final class HooksTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUserByIdHook::class);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findUserById = new FindUserByIdHook([
+            'user-123' => new User('user-123', 'https://example.com/avatars/123.png'),
+            'user-456' => new User('user-456', 'https://example.com/avatars/456.png'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient([
+                'data' => [
+                    'viewer' => [
+                        'login' => 'ruudk',
+                        'projects' => [
+                            [
+                                'name' => 'GraphQL Code Generator',
+                                'description' => null,
+                                'creator' => [
+                                    'id' => 'user-123',
+                                ],
+                            ],
+                            [
+                                'name' => 'Some Other Project',
+                                'description' => 'A project',
+                                'creator' => [
+                                    'id' => 'user-456',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+            [
+                'findUserById' => $findUserById,
+            ],
+        )->execute();
+
+        self::assertSame('ruudk', $result->viewer->login);
+        self::assertCount(2, $result->viewer->projects);
+
+        [$first, $second] = $result->viewer->projects;
+
+        self::assertSame('GraphQL Code Generator', $first->name);
+        self::assertNotNull($first->user);
+        self::assertSame('user-123', $first->user->id);
+        self::assertSame('https://example.com/avatars/123.png', $first->user->avatar);
+
+        self::assertSame('Some Other Project', $second->name);
+        self::assertNotNull($second->user);
+        self::assertSame('user-456', $second->user->id);
+        self::assertSame('https://example.com/avatars/456.png', $second->user->avatar);
+    }
+}

--- a/tests/Hooks/Schema.graphql
+++ b/tests/Hooks/Schema.graphql
@@ -1,0 +1,19 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    description: String
+    creator: User!
+}
+
+type User {
+    id: ID!
+}

--- a/tests/Hooks/Test.graphql
+++ b/tests/Hooks/Test.graphql
@@ -1,0 +1,14 @@
+query Test {
+    viewer {
+        login
+        projects {
+            name
+            description
+            creator {
+                id
+            }
+
+            user @hook(name: "findUserById", input: ["creator.id"])
+        }
+    }
+}

--- a/tests/Hooks/User.php
+++ b/tests/Hooks/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Hooks;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $avatar,
+    ) {}
+}

--- a/tests/HooksWithSymfonyAutowire/FindUserByIdHook.php
+++ b/tests/HooksWithSymfonyAutowire/FindUserByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    public function __invoke(string $id) : ?User
+    {
+        return $this->users[$id] ?? null;
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer'], $this->hooks);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *         'projects': list<array{
+     *             'creator': array{
+     *                 'id': string,
+     *             },
+     *             'description': null|string,
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item, $this->hooks), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     *     'projects': list<array{
+     *         'creator': array{
+     *             'id': string,
+     *         },
+     *         'description': null|string,
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data\Viewer\Project\Creator;
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\User;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public Creator $creator {
+        get => $this->creator ??= new Creator($this->data['creator']);
+    }
+
+    public ?string $description {
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    public ?User $user {
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'description': null|string,
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Creator
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Error.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            projects {
+              name
+              description
+              creator {
+                id
+              }
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        #[Autowire([
+            'findUserById' => new Autowire(service: FindUserByIdHook::class)
+        ])]
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/HooksWithSymfonyAutowireTest.php
+++ b/tests/HooksWithSymfonyAutowire/HooksWithSymfonyAutowireTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire\Generated\Query\Test\TestQuery;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class HooksWithSymfonyAutowireTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUserByIdHook::class)
+            ->enableSymfonyAutowireHooks();
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findUserById = new FindUserByIdHook([
+            'user-123' => new User('user-123', 'https://example.com/avatars/123.png'),
+            'user-456' => new User('user-456', 'https://example.com/avatars/456.png'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient($this->getResponseData()),
+            [
+                'findUserById' => $findUserById,
+            ],
+        )->execute();
+
+        $this->assertResult($result);
+    }
+
+    /**
+     * Exercises the generated `#[Autowire]` attribute by letting a real Symfony
+     * container build the TestQuery. If the attribute shape is wrong, compilation
+     * or service resolution fails here.
+     */
+    public function testQueryWithContainer() : void
+    {
+        $client = $this->getClient($this->getResponseData());
+
+        $container = new ContainerBuilder();
+
+        $container->register(TestClient::class)
+            ->setSynthetic(true)
+            ->setPublic(true);
+
+        $container->register(FindUserByIdHook::class)
+            ->setArgument('$users', [
+                'user-123' => new User('user-123', 'https://example.com/avatars/123.png'),
+                'user-456' => new User('user-456', 'https://example.com/avatars/456.png'),
+            ]);
+
+        $container->register(TestQuery::class)
+            ->setArgument('$client', new Reference(TestClient::class))
+            ->setAutowired(true)
+            ->setPublic(true);
+
+        $container->compile();
+        $container->set(TestClient::class, $client);
+
+        $query = $container->get(TestQuery::class);
+        self::assertInstanceOf(TestQuery::class, $query);
+
+        $this->assertResult($query->execute());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getResponseData() : array
+    {
+        return [
+            'data' => [
+                'viewer' => [
+                    'login' => 'ruudk',
+                    'projects' => [
+                        [
+                            'name' => 'GraphQL Code Generator',
+                            'description' => null,
+                            'creator' => [
+                                'id' => 'user-123',
+                            ],
+                        ],
+                        [
+                            'name' => 'Some Other Project',
+                            'description' => 'A project',
+                            'creator' => [
+                                'id' => 'user-456',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function assertResult(Generated\Query\Test\Data $result) : void
+    {
+        self::assertSame('ruudk', $result->viewer->login);
+        self::assertCount(2, $result->viewer->projects);
+
+        [$first, $second] = $result->viewer->projects;
+
+        self::assertSame('GraphQL Code Generator', $first->name);
+        self::assertNotNull($first->user);
+        self::assertSame('user-123', $first->user->id);
+        self::assertSame('https://example.com/avatars/123.png', $first->user->avatar);
+
+        self::assertSame('Some Other Project', $second->name);
+        self::assertNotNull($second->user);
+        self::assertSame('user-456', $second->user->id);
+        self::assertSame('https://example.com/avatars/456.png', $second->user->avatar);
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/Schema.graphql
+++ b/tests/HooksWithSymfonyAutowire/Schema.graphql
@@ -1,0 +1,19 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    description: String
+    creator: User!
+}
+
+type User {
+    id: ID!
+}

--- a/tests/HooksWithSymfonyAutowire/Test.graphql
+++ b/tests/HooksWithSymfonyAutowire/Test.graphql
@@ -1,0 +1,14 @@
+query Test {
+    viewer {
+        login
+        projects {
+            name
+            description
+            creator {
+                id
+            }
+
+            user @hook(name: "findUserById", input: ["creator.id"])
+        }
+    }
+}

--- a/tests/HooksWithSymfonyAutowire/User.php
+++ b/tests/HooksWithSymfonyAutowire/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithSymfonyAutowire;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $avatar,
+    ) {}
+}


### PR DESCRIPTION
Generated response objects can now expose properties that are not backed by the GraphQL response but resolved at access time by user-supplied code. The common case: the server returns a scalar (typically an id), and the application wants the corresponding domain object (fetched from a local database or cache) to appear on the response next to the existing fields, as if the GraphQL server had returned it.

The directive is a generator-only marker. It is stripped from the operation document before schema validation and before the request is sent, so the server never sees it.

Usage

Define an invokable class and tag it with `#[Hook(name: ...)]`:

    #[Hook(name: "findUserById")]
    final readonly class FindUserByIdHook {
        public function __construct(private UserRepository $users) {}

        public function __invoke(string $id): ?User
        {
            return $this->users->find($id);
        }
    }

Register it once:

    Config::create(...)
        ->withHook(FindUserByIdHook::class);

And reference it from a query with a synthetic field:

    query Project {
        project(id: "42") {
            name
            creator { id }
            user @hook(name: "findUserById", input: ["creator.id"])
        }
    }

`input` is a list of dotted paths resolved against the enclosing selection. Each path becomes a positional argument to `__invoke` in order, so a hook with `input: ["a.b", "c"]` is invoked as `$hook->__invoke($data[a][b], $data[c])`.

The generated Project class gains a lazy `$user` property that caches after first access:

    public ?User $user {
        get => $this->user ??= $this->hooks['findUserById']->__invoke(
            $this->data['creator']['id'],
        );
    }

How it works

- `src/Attribute/Hook.php` – attribute carrying the hook name; lives on the   hook class itself.
- `src/Config/HookDefinition.php` and `Config::withHook()` – register a hook.   The class must define `__invoke`. The return type is inferred from the   `__invoke` signature via Symfony TypeInfo's ReflectionReturnTypeResolver,   so config never has to restate it.
- `src/GraphQL/HookDirectiveSchemaExtender.php` – mirrors `IndexByDirective`:   adds `directive @hook(name: String!, input: [String!]!) on FIELD` to the   schema only when any hook is registered.
- `src/Visitor/HookFieldRemover.php` – strips every FIELD carrying `@hook`   from a document. Invoked twice in `Planner::planOperation`: once against   a copy fed to `DocumentValidator::validate` (hook field names are not in   the schema, so default `FieldsOnCorrectType` would reject them), and once   against the document printed into `OPERATION_DEFINITION`. The original AST   passed to the planner keeps its hook fields so they produce properties.
- `src/Planner/PayloadShapeBuilder.php` – skips FIELDs with `@hook` when   building the `@param array{...} $data` shape, keeping the payload pure.
- `src/Planner/SelectionSetPlanner::processFieldSelection` – when it sees a   field with `@hook`, looks up the `HookDefinition`, adds a `HookPropertyType`   entry to the field collection (carrying hook name + input paths + return   type), and returns early instead of resolving against the schema.
- `src/Type/HookPropertyType.php` – a marker type that wraps the hook's   return type. Implements `WrappingTypeInterface` so existing type dumpers   (DataClassGenerator, `TypeDumper`, `AbstractGenerator::dumpPHPType`) treat   it transparently and emit the real PHP type on the property annotation.
- `src/Planner.php::propagateUsedHooks` – runs after all plans are built.   Walks every `DataClassPlan`'s fields in one pass, collecting both direct   hook uses and child-class FQCNs, then iterates to a fixed point so every   plan that *transitively* constructs a hook-using child knows to accept   and forward the `$hooks` constructor arg.
- `src/TypeInitializer/ClassHookUsageRegistry.php` – populated by   `PlanExecutor::execute()` before emission. Consulted by   `ObjectTypeInitializer` so `new Child($data)` becomes `new Child($data,   $this->hooks)` whenever the child needs hooks, and by   `OperationClassGenerator` so the generated operation class knows what   hooks the root Data class requires.

Runtime shape

At every class that transitively hosts a hook, the generator emits a new constructor parameter with a typed shape:

    /**
     * @param array{
     *     'findUserById': FindUserByIdHook,
     * } $hooks
     */
    public function __construct(
        private readonly array $data,
        private readonly array $hooks,
    ) {}

PHPStan sees `$this->hooks['findUserById']` as `FindUserByIdHook`, catching renamed-hook typos at static-analysis time.

The hook property getter uses `dumpCall()` so call formatting matches the rest of the generator (single-arg calls inline, multi-arg calls wrap).

Symfony autowire

`Config::enableSymfonyAutowireHooks()` opts into a Symfony-specific convenience on the generated operation class only (not on intermediate Data classes – the array is built once on the client boundary and threaded down untouched):

    public function __construct(
        private TestClient $client,
        #[Autowire([
            'findUserById' => new Autowire(service: FindUserByIdHook::class)
        ])]
        private array $hooks,
    ) {}

With this in place the whole graph compose via `ContainerBuilder` with `setAutowired(true)` – `HooksWithSymfonyAutowireTest::testQueryWithContainer` exercises it end-to-end by actually resolving the query from a live container and asserting hooks return populated entities.

Tests

- `tests/Hooks/` – plain fixture: one invokable hook class, one directive   use, byte-for-byte `testGenerate` and a `testQuery` using manually-wired   hooks.
- `tests/HooksWithSymfonyAutowire/` – same shape with `enableSymfony AutowireHooks()` enabled. Verifies the generated `#[Autowire]` attribute   is correct, and that a real Symfony `ContainerBuilder` can autowire the   query (catches attribute-shape regressions the byte-comparison cannot).

README gets a "Local Resolution with @hook Directive" section covering hook class definition, config, directive syntax, runtime usage, and the Symfony autowire shortcut.
