### PR TITLE
Run user type initializers before the catch-all ObjectTypeInitializer

### DIFF
--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -63,15 +63,18 @@ final class PlanExecutor
     ) {
         $this->hookUsageRegistry = new ClassHookUsageRegistry();
 
-        // Initialize type initializer
-        $typeInitializer = new DelegatingTypeInitializer(
+        // User-registered initializers run before the catch-all `ObjectTypeInitializer`
+        // so type-specific handlers (e.g. Money) match ahead of the generic fallback.
+        $initializers = [
             new NullableTypeInitializer(),
             new IndexByCollectionTypeInitializer(),
             new CollectionTypeInitializer(),
             new BackedEnumTypeInitializer($config->addUnknownCaseToEnums, $config->namespace),
-            new ObjectTypeInitializer()->setHookUsageRegistry($this->hookUsageRegistry),
             ...$config->typeInitializers,
-        );
+            new ObjectTypeInitializer($this->hookUsageRegistry),
+        ];
+
+        $typeInitializer = new DelegatingTypeInitializer(...$initializers);
 
         // Initialize all generators
         $this->dataClassGenerator = new DataClassGenerator($config, $typeInitializer);

--- a/src/TypeInitializer/ObjectTypeInitializer.php
+++ b/src/TypeInitializer/ObjectTypeInitializer.php
@@ -4,35 +4,23 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\TypeInitializer;
 
-use Generator;
 use Override;
 use Ruudk\CodeGenerator\CodeGenerator;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 /**
+ * @internal Catch-all fallback owned by `PlanExecutor`. Userland should register
+ *           type-specific `TypeInitializer` instances via `Config::withTypeInitializer()`;
+ *           they run before this one.
+ *
  * @implements TypeInitializer<Type\ObjectType<*>>
  */
-final class ObjectTypeInitializer implements TypeInitializer
+final readonly class ObjectTypeInitializer implements TypeInitializer
 {
-    /**
-     * @var list<TypeInitializer>
-     */
-    private array $initializers;
-    private ?ClassHookUsageRegistry $hookUsageRegistry = null;
-
     public function __construct(
-        TypeInitializer ...$initializers,
-    ) {
-        $this->initializers = array_values($initializers);
-    }
-
-    public function setHookUsageRegistry(ClassHookUsageRegistry $registry) : self
-    {
-        $this->hookUsageRegistry = $registry;
-
-        return $this;
-    }
+        private ClassHookUsageRegistry $hookUsageRegistry,
+    ) {}
 
     #[Override]
     public function supports(Type $type) : bool
@@ -46,16 +34,8 @@ final class ObjectTypeInitializer implements TypeInitializer
         CodeGenerator $generator,
         string $variable,
         DelegatingTypeInitializer $delegator,
-    ) : Generator | string {
-        foreach ($this->initializers as $initializer) {
-            if ( ! $initializer->supports($type)) {
-                continue;
-            }
-
-            return $initializer->initialize($type, $generator, $variable, $delegator);
-        }
-
-        $arguments = $this->hookUsageRegistry?->usesHooks($type->getClassName()) === true
+    ) : string {
+        $arguments = $this->hookUsageRegistry->usesHooks($type->getClassName())
             ? sprintf('%s, $this->hooks', $variable)
             : $variable;
 

--- a/tests/HooksWithCustomTypeInitializer/FindUserByIdHook.php
+++ b/tests/HooksWithCustomTypeInitializer/FindUserByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    public function __invoke(string $id) : ?User
+    {
+        return $this->users[$id] ?? null;
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer'], $this->hooks);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'homepage': array{
+     *             'href': string,
+     *         },
+     *         'login': string,
+     *         'projects': list<array{
+     *             'creator': array{
+     *                 'id': string,
+     *             },
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data\Viewer\Project;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Url;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public Url $homepage {
+        get => $this->homepage ??= new Url($this->data['homepage']['href']);
+    }
+
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item, $this->hooks), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'homepage': array{
+     *         'href': string,
+     *     },
+     *     'login': string,
+     *     'projects': list<array{
+     *         'creator': array{
+     *             'id': string,
+     *         },
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data\Viewer\Project\Creator;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\User;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public Creator $creator {
+        get => $this->creator ??= new Creator($this->data['creator']);
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    public ?User $user {
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Creator
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Error.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            homepage {
+              href
+            }
+            projects {
+              name
+              creator {
+                id
+              }
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/HooksWithCustomTypeInitializerTest.php
+++ b/tests/HooksWithCustomTypeInitializer/HooksWithCustomTypeInitializerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer;
+
+use Generator;
+use Override;
+use Ruudk\CodeGenerator\CodeGenerator;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer\Generated\Query\Test\TestQuery;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
+use Ruudk\GraphQLCodeGenerator\TypeInitializer\TypeInitializer;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+final class HooksWithCustomTypeInitializerTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUserByIdHook::class)
+            ->withObjectType(
+                'Url',
+                Type::arrayShape([
+                    'href' => [
+                        'type' => Type::string(),
+                        'optional' => false,
+                    ],
+                ]),
+                Type::object(Url::class),
+            )
+            ->withIgnoreType('Url')
+            ->withTypeInitializer(
+                new class implements TypeInitializer {
+                    #[Override]
+                    public function supports(Type $type) : bool
+                    {
+                        return $type instanceof ObjectType && $type->getClassName() === Url::class;
+                    }
+
+                    /**
+                     * @return Generator<string>
+                     */
+                    #[Override]
+                    public function initialize(Type $type, CodeGenerator $generator, string $variable, DelegatingTypeInitializer $delegator) : Generator
+                    {
+                        yield sprintf('new %s(%s[\'href\'])', $generator->import(Url::class), $variable);
+                    }
+                },
+            );
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findUserById = new FindUserByIdHook([
+            'user-123' => new User('user-123', 'Alice'),
+            'user-456' => new User('user-456', 'Bob'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient($this->getResponseData()),
+            [
+                'findUserById' => $findUserById,
+            ],
+        )->execute();
+
+        self::assertSame('ruudk', $result->viewer->login);
+        self::assertSame('https://example.com', $result->viewer->homepage->href);
+        self::assertCount(2, $result->viewer->projects);
+
+        [$first, $second] = $result->viewer->projects;
+
+        self::assertSame('GraphQL Code Generator', $first->name);
+        self::assertSame('user-123', $first->creator->id);
+        self::assertNotNull($first->user);
+        self::assertSame('Alice', $first->user->name);
+
+        self::assertSame('Some Other Project', $second->name);
+        self::assertSame('user-456', $second->creator->id);
+        self::assertNotNull($second->user);
+        self::assertSame('Bob', $second->user->name);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getResponseData() : array
+    {
+        return [
+            'data' => [
+                'viewer' => [
+                    'login' => 'ruudk',
+                    'homepage' => [
+                        'href' => 'https://example.com',
+                    ],
+                    'projects' => [
+                        [
+                            'name' => 'GraphQL Code Generator',
+                            'creator' => [
+                                'id' => 'user-123',
+                            ],
+                        ],
+                        [
+                            'name' => 'Some Other Project',
+                            'creator' => [
+                                'id' => 'user-456',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/Schema.graphql
+++ b/tests/HooksWithCustomTypeInitializer/Schema.graphql
@@ -1,0 +1,23 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    homepage: Url!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    creator: Creator!
+}
+
+type Creator {
+    id: ID!
+}
+
+type Url {
+    href: String!
+}

--- a/tests/HooksWithCustomTypeInitializer/Test.graphql
+++ b/tests/HooksWithCustomTypeInitializer/Test.graphql
@@ -1,0 +1,16 @@
+query Test {
+    viewer {
+        login
+        homepage {
+            href
+        }
+        projects {
+            name
+            creator {
+                id
+            }
+
+            user @hook(name: "findUserById", input: ["creator.id"])
+        }
+    }
+}

--- a/tests/HooksWithCustomTypeInitializer/Url.php
+++ b/tests/HooksWithCustomTypeInitializer/Url.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer;
+
+final readonly class Url
+{
+    public function __construct(
+        public string $href,
+    ) {}
+}

--- a/tests/HooksWithCustomTypeInitializer/User.php
+++ b/tests/HooksWithCustomTypeInitializer/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithCustomTypeInitializer;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+}

--- a/tests/Money/MoneyTest.php
+++ b/tests/Money/MoneyTest.php
@@ -15,7 +15,6 @@ use Ruudk\GraphQLCodeGenerator\Money\ValueObjects\Currency;
 use Ruudk\GraphQLCodeGenerator\Money\ValueObjects\Money;
 use Ruudk\GraphQLCodeGenerator\Type\PseudoType;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
-use Ruudk\GraphQLCodeGenerator\TypeInitializer\ObjectTypeInitializer;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\TypeInitializer;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
@@ -45,29 +44,27 @@ final class MoneyTest extends GraphQLTestCase
             ->withIgnoreType('MoneyInput')
             ->withIgnoreType('Money')
             ->withTypeInitializer(
-                new ObjectTypeInitializer(
-                    new class implements TypeInitializer {
-                        #[Override]
-                        public function supports(Type $type) : bool
-                        {
-                            return $type instanceof ObjectType && $type->getClassName() === Money::class;
-                        }
+                new class implements TypeInitializer {
+                    #[Override]
+                    public function supports(Type $type) : bool
+                    {
+                        return $type instanceof ObjectType && $type->getClassName() === Money::class;
+                    }
 
-                        /**
-                         * @return Generator<\Ruudk\CodeGenerator\Group|string>
-                         */
-                        #[Override]
-                        public function initialize(Type $type, CodeGenerator $generator, string $variable, DelegatingTypeInitializer $delegator) : Generator
-                        {
-                            yield sprintf('new %s(', $generator->import(Money::class));
-                            yield $generator->indent(function () use ($generator, $variable) {
-                                yield sprintf("%s['amount'],", $variable);
-                                yield sprintf("new %s(%s['currency']),", $generator->import(Currency::class), $variable);
-                            });
-                            yield ')';
-                        }
-                    },
-                ),
+                    /**
+                     * @return Generator<\Ruudk\CodeGenerator\Group|string>
+                     */
+                    #[Override]
+                    public function initialize(Type $type, CodeGenerator $generator, string $variable, DelegatingTypeInitializer $delegator) : Generator
+                    {
+                        yield sprintf('new %s(', $generator->import(Money::class));
+                        yield $generator->indent(function () use ($generator, $variable) {
+                            yield sprintf("%s['amount'],", $variable);
+                            yield sprintf("new %s(%s['currency']),", $generator->import(Currency::class), $variable);
+                        });
+                        yield ')';
+                    }
+                },
             );
     }
 


### PR DESCRIPTION
The `@hook` directive added in #43 forwards `$this->hooks` into child constructors via `ObjectTypeInitializer`, which consults a `ClassHookUsageRegistry` owned by `PlanExecutor`. Projects that registered their own `ObjectTypeInitializer` via `Config::withTypeInitializer()` to customize a specific value object (Money, Url, …) broke the hook forwarding: the dedup-by-class-name in `DelegatingTypeInitializer` let the user instance — constructed without the registry — overwrite the built-in one, so every `new Child($data)` was emitted without hooks.

Splitting the two roles removes the footgun. `ObjectTypeInitializer` is now strictly the internal catch-all (registry injected via constructor, no extension surface). Userland registers plain `TypeInitializer` instances that match only their specific class; the delegation chain runs them ahead of the catch-all, so type-specific handlers win for their own types and everything else falls through to the built-in one with hooks intact.

Breaking change for any config that wrapped a handler in `ObjectTypeInitializer` — unwrap it and pass the inner `TypeInitializer` directly to `withTypeInitializer()`.
