### PR TITLE
Forward $hooks through fragment-spread getters

### DIFF
--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -33,6 +33,21 @@ final class DataClassGenerator extends AbstractGenerator
         parent::__construct($config);
     }
 
+    /**
+     * Delegates fragment-spread construction to the type initializer so the
+     * single source of truth (`ObjectTypeInitializer` + `ClassHookUsageRegistry`)
+     * decides whether to forward `$this->hooks` into the child constructor.
+     *
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     */
+    private function initializeFragmentObject(FragmentObjectType $type, CodeGenerator $generator) : string
+    {
+        $result = $this->typeInitializer->__invoke($type, $generator, '$this->data');
+        Assert::string($result);
+
+        return $result;
+    }
+
     public function generate(DataClassPlan $plan) : string
     {
         $parentType = $plan->parentType;
@@ -238,13 +253,15 @@ final class DataClassGenerator extends AbstractGenerator
                                          */
                                         $requiredFields = $requiredFieldsMap[$fragmentClassName] ?? [];
 
+                                        $construct = $this->initializeFragmentObject($nakedFieldType, $generator);
+
                                         // For fragments on interface/union types themselves
                                         if ($nakedFieldType->fragmentType instanceof InterfaceType || $nakedFieldType->fragmentType instanceof UnionType) {
                                             yield sprintf(
-                                                'get => $this->%s ??= in_array($this->data[\'__typename\'], %s::POSSIBLE_TYPES, true) ? new %s($this->data) : null;',
+                                                'get => $this->%s ??= in_array($this->data[\'__typename\'], %s::POSSIBLE_TYPES, true) ? %s : null;',
                                                 $fieldName,
                                                 $generator->import($nakedFieldType->getClassName()),
-                                                $generator->import($nakedFieldType->getClassName()),
+                                                $construct,
                                             );
 
                                             return;
@@ -255,15 +272,15 @@ final class DataClassGenerator extends AbstractGenerator
                                         if ($requiredFields === []) {
                                             // No required fields to check, only typename
                                             yield sprintf(
-                                                'get => $this->%s ??= $this->data[\'__typename\'] === %s ? new %s($this->data) : null;',
+                                                'get => $this->%s ??= $this->data[\'__typename\'] === %s ? %s : null;',
                                                 $fieldName,
                                                 var_export($nakedFieldType->fragmentType->name(), true),
-                                                $generator->import($nakedFieldType->getClassName()),
+                                                $construct,
                                             );
                                         } else {
                                             // Generate verbose getter with field checks for PHPStan type safety
                                             yield 'get {';
-                                            yield $generator->indent(function () use ($fieldName, $nakedFieldType, $generator, $requiredFields) {
+                                            yield $generator->indent(function () use ($fieldName, $nakedFieldType, $requiredFields, $construct) {
                                                 yield sprintf('if (isset($this->%s)) {', $fieldName);
                                                 yield '    return $this->' . $fieldName . ';';
                                                 yield '}';
@@ -288,9 +305,9 @@ final class DataClassGenerator extends AbstractGenerator
 
                                                 yield '';
                                                 yield sprintf(
-                                                    'return $this->%s = new %s($this->data);',
+                                                    'return $this->%s = %s;',
                                                     $fieldName,
-                                                    $generator->import($nakedFieldType->getClassName()),
+                                                    $construct,
                                                 );
                                             });
                                             yield '}';
@@ -301,9 +318,9 @@ final class DataClassGenerator extends AbstractGenerator
 
                                     // For ObjectType parents, fragments don't need field checking
                                     yield sprintf(
-                                        'get => $this->%s ??= new %s($this->data);',
+                                        'get => $this->%s ??= %s;',
                                         $fieldName,
-                                        $generator->import($nakedFieldType->getClassName()),
+                                        $this->initializeFragmentObject($nakedFieldType, $generator),
                                     );
 
                                     return;

--- a/tests/HooksWithFragmentSpread/FindUserByIdHook.php
+++ b/tests/HooksWithFragmentSpread/FindUserByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    public function __invoke(string $id) : ?User
+    {
+        return $this->users[$id] ?? null;
+    }
+}

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectListing.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectListing.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+
+// This file was automatically generated and should not be edited.
+
+final class ProjectListing
+{
+    public ?string $description {
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
+    }
+
+    public ProjectSummary $projectSummary {
+        get => $this->projectSummary ??= new ProjectSummary($this->data, $this->hooks);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'description': null|string,
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment\ProjectSummary\Creator;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\User;
+
+// This file was automatically generated and should not be edited.
+
+final class ProjectSummary
+{
+    public Creator $creator {
+        get => $this->creator ??= new Creator($this->data['creator']);
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    public ?User $user {
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary/Creator.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary/Creator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment\ProjectSummary;
+
+// This file was automatically generated and should not be edited.
+
+final class Creator
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer'], $this->hooks);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *         'projects': list<array{
+     *             'creator': array{
+     *                 'id': string,
+     *             },
+     *             'description': null|string,
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item, $this->hooks), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     *     'projects': list<array{
+     *         'creator': array{
+     *             'id': string,
+     *         },
+     *         'description': null|string,
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment\ProjectListing;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public ?string $description {
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
+    }
+
+    public ProjectListing $projectListing {
+        get => $this->projectListing ??= new ProjectListing($this->data, $this->hooks);
+    }
+
+    /**
+     * @param array{
+     *     'creator': array{
+     *         'id': string,
+     *     },
+     *     'description': null|string,
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Error.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            projects {
+              ...ProjectListing
+            }
+          }
+        }
+        
+        fragment ProjectListing on Project {
+          ...ProjectSummary
+          description
+        }
+        
+        fragment ProjectSummary on Project {
+          name
+          creator {
+            id
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        #[Autowire([
+            'findUserById' => new Autowire(service: FindUserByIdHook::class)
+        ])]
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksWithFragmentSpread/HooksWithFragmentSpreadTest.php
+++ b/tests/HooksWithFragmentSpread/HooksWithFragmentSpreadTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Query\Test\TestQuery;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class HooksWithFragmentSpreadTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUserByIdHook::class)
+            ->enableSymfonyAutowireHooks();
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findUserById = new FindUserByIdHook([
+            'user-123' => new User('user-123', 'https://example.com/avatars/123.png'),
+            'user-456' => new User('user-456', 'https://example.com/avatars/456.png'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient($this->getResponseData()),
+            [
+                'findUserById' => $findUserById,
+            ],
+        )->execute();
+
+        $this->assertResult($result);
+    }
+
+    /**
+     * Exercises the `#[Autowire]` attribute by letting a real Symfony container
+     * build the TestQuery. If the attribute shape is wrong or the hook is not
+     * forwarded through the fragment-spread chain, compilation or service
+     * resolution fails here.
+     */
+    public function testQueryWithContainer() : void
+    {
+        $client = $this->getClient($this->getResponseData());
+
+        $container = new ContainerBuilder();
+
+        $container->register(TestClient::class)
+            ->setSynthetic(true)
+            ->setPublic(true);
+
+        $container->register(FindUserByIdHook::class)
+            ->setArgument('$users', [
+                'user-123' => new User('user-123', 'https://example.com/avatars/123.png'),
+                'user-456' => new User('user-456', 'https://example.com/avatars/456.png'),
+            ]);
+
+        $container->register(TestQuery::class)
+            ->setArgument('$client', new Reference(TestClient::class))
+            ->setAutowired(true)
+            ->setPublic(true);
+
+        $container->compile();
+        $container->set(TestClient::class, $client);
+
+        $query = $container->get(TestQuery::class);
+        self::assertInstanceOf(TestQuery::class, $query);
+
+        $this->assertResult($query->execute());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getResponseData() : array
+    {
+        return [
+            'data' => [
+                'viewer' => [
+                    'login' => 'ruudk',
+                    'projects' => [
+                        [
+                            'name' => 'GraphQL Code Generator',
+                            'description' => null,
+                            'creator' => [
+                                'id' => 'user-123',
+                            ],
+                        ],
+                        [
+                            'name' => 'Some Other Project',
+                            'description' => 'A project',
+                            'creator' => [
+                                'id' => 'user-456',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function assertResult(Generated\Query\Test\Data $result) : void
+    {
+        self::assertSame('ruudk', $result->viewer->login);
+        self::assertCount(2, $result->viewer->projects);
+
+        [$first, $second] = $result->viewer->projects;
+
+        self::assertSame('GraphQL Code Generator', $first->projectListing->projectSummary->name);
+        self::assertNotNull($first->projectListing->projectSummary->user);
+        self::assertSame('user-123', $first->projectListing->projectSummary->user->id);
+        self::assertSame('https://example.com/avatars/123.png', $first->projectListing->projectSummary->user->avatar);
+
+        self::assertSame('A project', $second->projectListing->description);
+        self::assertNotNull($second->projectListing->projectSummary->user);
+        self::assertSame('user-456', $second->projectListing->projectSummary->user->id);
+        self::assertSame('https://example.com/avatars/456.png', $second->projectListing->projectSummary->user->avatar);
+    }
+}

--- a/tests/HooksWithFragmentSpread/ProjectListing.graphql
+++ b/tests/HooksWithFragmentSpread/ProjectListing.graphql
@@ -1,0 +1,4 @@
+fragment ProjectListing on Project {
+    ...ProjectSummary
+    description
+}

--- a/tests/HooksWithFragmentSpread/ProjectSummary.graphql
+++ b/tests/HooksWithFragmentSpread/ProjectSummary.graphql
@@ -1,0 +1,8 @@
+fragment ProjectSummary on Project {
+    name
+    creator {
+        id
+    }
+
+    user @hook(name: "findUserById", input: ["creator.id"])
+}

--- a/tests/HooksWithFragmentSpread/Schema.graphql
+++ b/tests/HooksWithFragmentSpread/Schema.graphql
@@ -1,0 +1,19 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    description: String
+    creator: User!
+}
+
+type User {
+    id: ID!
+}

--- a/tests/HooksWithFragmentSpread/Test.graphql
+++ b/tests/HooksWithFragmentSpread/Test.graphql
@@ -1,0 +1,8 @@
+query Test {
+    viewer {
+        login
+        projects {
+            ...ProjectListing
+        }
+    }
+}

--- a/tests/HooksWithFragmentSpread/User.php
+++ b/tests/HooksWithFragmentSpread/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $avatar,
+    ) {}
+}


### PR DESCRIPTION
PR #43 taught data classes to accept and store $hooks, and the planner marks every transitive parent as hook-using -- but the fragment-spread getter templates in DataClassGenerator kept hard-coding `new Child($this->data)`, so the stored hooks never reached the child. PHPStan flagged each intermediate class with arguments.count on the child constructor and property.onlyWritten on its own $hooks property.

Delegate the constructor expression to $typeInitializer, which already consults ClassHookUsageRegistry via ObjectTypeInitializer, instead of rebuilding `new X(...)` by hand in four places.
