### PR TITLE
Make queriesDir optional via withQueriesDir builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ return Config::create(
     // https://docs.github.com/public/fpt/schema.docs.graphql
     schema: __DIR__ . '/schema.docs.graphql',
     projectDir: __DIR__,
-    queriesDir: __DIR__,
     outputDir: __DIR__ . '/Generated',
     namespace: 'Ruudk\GraphQLCodeGenerator\Examples\Generated',
     client: GitHubClient::class,
 )
+    ->withQueriesDir(__DIR__)
     ->withIntrospectionClient(function () {
         $dotenv = new Dotenv();
         $dotenv->bootEnv(__DIR__ . '/.env.local');

--- a/examples/config.php
+++ b/examples/config.php
@@ -12,11 +12,11 @@ return Config::create(
     // https://docs.github.com/public/fpt/schema.docs.graphql
     schema: __DIR__ . '/schema.docs.graphql',
     projectDir: __DIR__,
-    queriesDir: __DIR__,
     outputDir: __DIR__ . '/Generated',
     namespace: 'Ruudk\GraphQLCodeGenerator\Examples\Generated',
     client: GitHubClient::class,
 )
+    ->withQueriesDir(__DIR__)
     ->withIntrospectionClient(function () {
         $dotenv = new Dotenv();
         $dotenv->bootEnv(__DIR__ . '/.env.local');

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -34,10 +34,10 @@ final readonly class Config
     private function __construct(
         public Schema | string $schema,
         public string $projectDir,
-        public string $queriesDir,
         public string $outputDir,
         public string $namespace,
         public string $client,
+        public ?string $queriesDir = null,
         public bool $dumpOrThrows = false,
         public bool $dumpDefinition = false,
         public bool $useNodeNameForEdgeNodes = false,
@@ -66,18 +66,16 @@ final readonly class Config
     public static function create(
         Schema | string $schema,
         string $projectDir,
-        string $queriesDir,
         string $outputDir,
         string $namespace,
         string $client,
     ) : self {
         return new self(
-            $schema,
-            $projectDir,
-            $queriesDir,
-            $outputDir,
-            $namespace,
-            $client,
+            schema: $schema,
+            projectDir: $projectDir,
+            outputDir: $outputDir,
+            namespace: $namespace,
+            client: $client,
         );
     }
 
@@ -240,6 +238,13 @@ final readonly class Config
     {
         return clone ($this, [
             'introspectionClient' => $client,
+        ]);
+    }
+
+    public function withQueriesDir(string $queriesDir) : self
+    {
+        return clone ($this, [
+            'queriesDir' => $queriesDir,
         ]);
     }
 

--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -118,7 +118,7 @@ final class PlanExecutor
             }
         }
 
-        if ($this->config->formatOperationFiles) {
+        if ($this->config->formatOperationFiles && $this->config->queriesDir !== null) {
             $finder = Finder::create()->files()
                 ->in($this->config->queriesDir)
                 ->name('*.graphql')

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -221,42 +221,47 @@ final class Planner
      */
     public function plan() : PlannerResult
     {
-        $finder = Finder::create()->files()
-            ->in($this->config->queriesDir)
-            ->name('*.graphql')
-            ->sortByName();
-
-        if ($this->schemaLoader->schemaPath !== null) {
-            $finder->notPath(Path::makeRelative($this->schemaLoader->schemaPath, $this->config->queriesDir));
-        }
-
         $operations = [];
         $usedTypesCollector = new UsedTypesCollector($this->schema);
         $definedFragments = [];
 
-        // First pass: parse all queries to find what types are actually used
-        foreach ($finder as $file) {
-            $document = Parser::parse($file->getContents());
+        // Skip the .graphql finder when no queriesDir is configured — the caller
+        // only uses inline/Twig sources (e.g. `GeneratedGraphQLClient`), so there
+        // are no query files to discover.
+        if ($this->config->queriesDir !== null) {
+            $finder = Finder::create()->files()
+                ->in($this->config->queriesDir)
+                ->name('*.graphql')
+                ->sortByName();
 
-            $usedTypesCollector->analyze($document);
-
-            foreach (DefinedFragmentsVisitor::getDefinedFragments($document) as $name => $fragmentNode) {
-                if (isset($definedFragments[$name])) {
-                    throw new Exception(sprintf(
-                        'File "%s" defined fragment "%s" but it is already defined in "%s".',
-                        $definedFragments[$name],
-                        $name,
-                        $file->getPathname(),
-                    ));
-                }
-
-                $definedFragments[$name] = $file->getPathname();
+            if ($this->schemaLoader->schemaPath !== null) {
+                $finder->notPath(Path::makeRelative($this->schemaLoader->schemaPath, $this->config->queriesDir));
             }
 
-            $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
-                $document,
-                new GraphQLFileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
-            );
+            // First pass: parse all queries to find what types are actually used
+            foreach ($finder as $file) {
+                $document = Parser::parse($file->getContents());
+
+                $usedTypesCollector->analyze($document);
+
+                foreach (DefinedFragmentsVisitor::getDefinedFragments($document) as $name => $fragmentNode) {
+                    if (isset($definedFragments[$name])) {
+                        throw new Exception(sprintf(
+                            'File "%s" defined fragment "%s" but it is already defined in "%s".',
+                            $definedFragments[$name],
+                            $name,
+                            $file->getPathname(),
+                        ));
+                    }
+
+                    $definedFragments[$name] = $file->getPathname();
+                }
+
+                $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
+                    $document,
+                    new GraphQLFileSource(Path::makeRelative($file->getPathname(), $this->config->projectDir)),
+                );
+            }
         }
 
         $operationsToInject = [];

--- a/tests/Generator/AbstractGeneratorTest.php
+++ b/tests/Generator/AbstractGeneratorTest.php
@@ -13,7 +13,7 @@ final class AbstractGeneratorTest extends TestCase
 {
     public function testNullableCustomScalarUsesExplicitNullUnionInsteadOfNullableShorthand() : void
     {
-        $generator = new class(Config::create(schema: '', projectDir: '', queriesDir: '', outputDir: '', namespace: 'Test\\Generated', client: 'Test\\Client')) extends AbstractGenerator {
+        $generator = new class(Config::create(schema: '', projectDir: '', outputDir: '', namespace: 'Test\\Generated', client: 'Test\\Client')) extends AbstractGenerator {
             public function dump(SymfonyType $type) : string
             {
                 return $this->dumpPHPType($type, static fn(string $className) => $className);

--- a/tests/GraphQLTestCase.php
+++ b/tests/GraphQLTestCase.php
@@ -40,11 +40,10 @@ abstract class GraphQLTestCase extends TestCase
         return Config::create(
             schema: $this->directory . '/Schema.graphql',
             projectDir: dirname(__DIR__),
-            queriesDir: $this->directory,
             outputDir: $this->directory . '/Generated',
             namespace: $this->namespace . '\\Generated',
             client: TestClient::class,
-        );
+        )->withQueriesDir($this->directory);
     }
 
     protected function assertActualMatchesExpected() : void

--- a/tests/PHPStan/config.php
+++ b/tests/PHPStan/config.php
@@ -7,8 +7,7 @@ use Ruudk\GraphQLCodeGenerator\Config\Config;
 return Config::create(
     schema: __DIR__ . '/schema.docs.graphql',
     projectDir: __DIR__,
-    queriesDir: __DIR__,
     outputDir: __DIR__ . '/Generated',
     namespace: 'Ruudk\GraphQLCodeGenerator\PHPStan\Generated',
     client: 'DoesnotMatter',
-);
+)->withQueriesDir(__DIR__);

--- a/tests/Planner/NestedFragmentPayloadShapeTest.php
+++ b/tests/Planner/NestedFragmentPayloadShapeTest.php
@@ -23,11 +23,10 @@ final class NestedFragmentPayloadShapeTest extends TestCase
         $config = Config::create(
             schema: $tempDir . '/schema.graphql',
             projectDir: $tempDir,
-            queriesDir: $tempDir,
             outputDir: $tempDir . '/generated',
             namespace: 'Test\\Generated',
             client: 'TestClient',
-        );
+        )->withQueriesDir($tempDir);
         register_shutdown_function(function () use ($tempDir) : void {
             // Clean up temp files
             $files = new RecursiveIteratorIterator(


### PR DESCRIPTION
Consumers that feed all their operations through GeneratedGraphQLClient (inline or Twig sources) have no .graphql files on disk, so requiring a queriesDir forced them to invent a dummy path.

Drop queriesDir from Config::create() and add a withQueriesDir() builder so it's opt-in like the other dir-scoped settings (inlineProcessing, twigProcessing). Planner and PlanExecutor skip their .graphql finders when queriesDir is null. Breaking change: positional create() callers shift by one, and any caller that needs a queries directory now has to chain withQueriesDir() -- everything in-tree (tests, examples, README) is updated accordingly.
