### PR TITLE
Emit @var PHPDoc for hook-backed collection properties

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -11,4 +11,9 @@ $config->addPathToScan(__DIR__ . '/bin', isDev: false);
 
 $config->ignoreErrorsOnPackage('twig/twig', [ErrorType::DEV_DEPENDENCY_IN_PROD]);
 
+// phpstan/phpdoc-parser is never referenced directly. Symfony's TypeResolver
+// only enables @return / @param PHPDoc parsing when this package is loadable,
+// which the @hook directive relies on to resolve collection return types.
+$config->ignoreErrorsOnPackage('phpstan/phpdoc-parser', [ErrorType::UNUSED_DEPENDENCY]);
+
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": "^8.5",
         "composer-runtime-api": "^2.0",
         "nikic/php-parser": "^5.7",
+        "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1.18",
         "ruudk/code-generator": "^0.4.6",
         "sebastian/diff": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8c7468f68dcd50617fd4745c82c3162",
+    "content-hash": "5f6bc3ba7bce6cf23db62cefc152178d",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -63,6 +63,53 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
             "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -180,6 +180,16 @@ final class DataClassGenerator extends AbstractGenerator
                             // class) with positional arguments in the order declared by the
                             // directive.
                             if ($fieldType instanceof HookPropertyType) {
+                                $wrappedReturnType = $fieldType->getWrappedType();
+
+                                yield from $generator->docComment(function () use ($wrappedReturnType, $generator) {
+                                    if ($this->getNakedType($wrappedReturnType) instanceof SymfonyType\CollectionType) {
+                                        yield sprintf(
+                                            '@var %s',
+                                            TypeDumper::dump($wrappedReturnType, $generator->import(...)),
+                                        );
+                                    }
+                                });
                                 yield sprintf(
                                     'public %s $%s {',
                                     $this->dumpPHPType($fieldType, $generator->import(...)),

--- a/tests/HooksWithListReturn/FindUsersByIdsHook.php
+++ b/tests/HooksWithListReturn/FindUsersByIdsHook.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUsersByIds')]
+final readonly class FindUsersByIdsHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    /**
+     * @param list<string> $ids
+     * @return list<User>
+     */
+    public function __invoke(array $ids) : array
+    {
+        $out = [];
+
+        foreach ($ids as $id) {
+            if (isset($this->users[$id])) {
+                $out[] = $this->users[$id];
+            }
+        }
+
+        return $out;
+    }
+}

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\FindUsersByIdsHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        get => $this->viewer ??= new Viewer($this->data['viewer'], $this->hooks);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': array{
+     *         'login': string,
+     *         'projects': list<array{
+     *             'contributorIds': list<string>,
+     *             'name': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUsersByIds': FindUsersByIdsHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\FindUsersByIdsHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    /**
+     * @var list<Project>
+     */
+    public array $projects {
+        get => $this->projects ??= array_map(fn($item) => new Project($item, $this->hooks), $this->data['projects']);
+    }
+
+    /**
+     * @param array{
+     *     'login': string,
+     *     'projects': list<array{
+     *         'contributorIds': list<string>,
+     *         'name': string,
+     *     }>,
+     * } $data
+     * @param array{
+     *     'findUsersByIds': FindUsersByIdsHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test\Data\Viewer;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\FindUsersByIdsHook;
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\User;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    /**
+     * @var list<string>
+     */
+    public array $contributorIds {
+        get => $this->contributorIds ??= array_map(fn($item) => $item, $this->data['contributorIds']);
+    }
+
+    /**
+     * @var list<User>
+     */
+    public array $contributors {
+        get => $this->contributors ??= $this->hooks['findUsersByIds']->__invoke($this->data['contributorIds']);
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'contributorIds': list<string>,
+     *     'name': string,
+     * } $data
+     * @param array{
+     *     'findUsersByIds': FindUsersByIdsHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksWithListReturn/Generated/Query/Test/Error.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\FindUsersByIdsHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            projects {
+              name
+              contributorIds
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUsersByIds': FindUsersByIdsHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksWithListReturn/HooksWithListReturnTest.php
+++ b/tests/HooksWithListReturn/HooksWithListReturnTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksWithListReturn\Generated\Query\Test\TestQuery;
+
+final class HooksWithListReturnTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUsersByIdsHook::class);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findUsersByIds = new FindUsersByIdsHook([
+            'user-123' => new User('user-123', 'Alice'),
+            'user-456' => new User('user-456', 'Bob'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient([
+                'data' => [
+                    'viewer' => [
+                        'login' => 'ruudk',
+                        'projects' => [
+                            [
+                                'name' => 'GraphQL Code Generator',
+                                'contributorIds' => ['user-123', 'user-456'],
+                            ],
+                            [
+                                'name' => 'Some Other Project',
+                                'contributorIds' => ['user-123'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+            [
+                'findUsersByIds' => $findUsersByIds,
+            ],
+        )->execute();
+
+        self::assertSame('ruudk', $result->viewer->login);
+        self::assertCount(2, $result->viewer->projects);
+
+        [$first, $second] = $result->viewer->projects;
+
+        self::assertCount(2, $first->contributors);
+        self::assertSame('Alice', $first->contributors[0]->name);
+        self::assertSame('Bob', $first->contributors[1]->name);
+
+        self::assertCount(1, $second->contributors);
+        self::assertSame('Alice', $second->contributors[0]->name);
+    }
+}

--- a/tests/HooksWithListReturn/Schema.graphql
+++ b/tests/HooksWithListReturn/Schema.graphql
@@ -1,0 +1,18 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    login: String!
+    projects: [Project!]!
+}
+
+type Project {
+    id: ID!
+    name: String!
+    contributorIds: [ID!]!
+}
+
+type User {
+    id: ID!
+}

--- a/tests/HooksWithListReturn/Test.graphql
+++ b/tests/HooksWithListReturn/Test.graphql
@@ -1,0 +1,11 @@
+query Test {
+    viewer {
+        login
+        projects {
+            name
+            contributorIds
+
+            contributors @hook(name: "findUsersByIds", input: ["contributorIds"])
+        }
+    }
+}

--- a/tests/HooksWithListReturn/User.php
+++ b/tests/HooksWithListReturn/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksWithListReturn;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+}


### PR DESCRIPTION
Hook-backed properties (`@hook` directive) whose invokable returns a collection type (`list<X>`, `array<K, V>`) were generated as `public array $field { ... }` with no `@var` docblock. PHPStan at level 6+ rejects these with `missingType.iterableValue`, which made `@hook` effectively unusable for bulk-find-by-ids and other list-returning lookups — users had to wrap results in a boilerplate value object.

The regular-field branch of `DataClassGenerator` already emits `@var` when the naked property type is a `CollectionType`. The hook branch skipped that step entirely. Even if it hadn't, `getNakedType()` only unwraps `NullableType`, so passing a `HookPropertyType` wrapper through would never reach the inner collection. Fix by unwrapping `HookPropertyType` via `getWrappedType()` before the naked-type check and dumping the wrapped type (not the wrapper) through `TypeDumper`.

Also pulls `phpstan/phpdoc-parser` in as a runtime dependency. Symfony's `TypeResolver::create()` only wraps its reflection resolvers with `PhpDocAwareReflectionTypeResolver` when that package is loadable — without it, `@return list<User>` on a hook invokable falls back to `array<int|string, mixed>` and the inner value type is lost. Making it a hard dep means hook return types declared via PHPDoc resolve correctly out of the box. Whitelisted in `composer-dependency-analyser.php` because it's never imported directly; Symfony's TypeResolver probes for it via `class_exists`.

Regression test in `tests/HooksWithListReturn/` covers a list-returning hook end-to-end: generated output carries `@var list<User>` above the property, and the runtime invocation returns the expected objects.
