### PR TITLE
Detect unused hooks during --ensure-sync

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -146,7 +146,8 @@ final class GenerateCommand
                 $plan = new Planner($configItem)->plan();
 
                 // Execution phase - uses discovered types from plan
-                $files = new PlanExecutor($configItem)->execute($plan);
+                $executor = new PlanExecutor($configItem);
+                $files = $executor->execute($plan);
 
                 if ($ensureSync) {
                     $actual = [];
@@ -189,7 +190,26 @@ final class GenerateCommand
                         $io->error('Generated files are not in sync');
 
                         $exitCode = Command::FAILURE;
+                    }
 
+                    $usedHookNames = $executor->hookUsageRegistry->getAllUsedHookNames();
+                    $unusedHooks = array_diff_key($configItem->hooks, $usedHookNames);
+
+                    foreach ($unusedHooks as $hookName => $hookDefinition) {
+                        $io->warning(sprintf(
+                            'Hook "%s" (%s) is registered but is not used by any generated code',
+                            $hookName,
+                            $hookDefinition->class,
+                        ));
+                    }
+
+                    if ($unusedHooks !== []) {
+                        $exitCode = Command::FAILURE;
+
+                        continue;
+                    }
+
+                    if ($errors) {
                         continue;
                     }
 

--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -54,7 +54,7 @@ final class PlanExecutor
     private readonly ExceptionClassGenerator $exceptionClassGenerator;
     private readonly InputTypeGenerator $inputTypeGenerator;
     private readonly NodeNotFoundExceptionGenerator $nodeNotFoundExceptionGenerator;
-    private readonly ClassHookUsageRegistry $hookUsageRegistry;
+    public readonly ClassHookUsageRegistry $hookUsageRegistry;
     private Parser $phpParser;
     private Filesystem $filesystem;
 

--- a/src/TypeInitializer/ClassHookUsageRegistry.php
+++ b/src/TypeInitializer/ClassHookUsageRegistry.php
@@ -34,4 +34,20 @@ final class ClassHookUsageRegistry
     {
         return $this->classHooks[$fqcn] ?? [];
     }
+
+    /**
+     * Flat union of every hook name referenced by any generated class.
+     *
+     * @return array<string, true>
+     */
+    public function getAllUsedHookNames() : array
+    {
+        $names = [];
+
+        foreach ($this->classHooks as $hooks) {
+            $names += $hooks;
+        }
+
+        return $names;
+    }
 }

--- a/tests/Console/EnsureSyncCommandTest.php
+++ b/tests/Console/EnsureSyncCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Console;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class EnsureSyncCommandTest extends TestCase
+{
+    public function testEnsureSyncSucceedsWhenAllRegisteredHooksAreUsed() : void
+    {
+        $tester = $this->buildTester();
+
+        $exitCode = $tester->execute([
+            '--config' => [__DIR__ . '/Fixtures/with-only-used-hooks.php'],
+            '--ensure-sync' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('Generated code is in sync', $tester->getDisplay());
+    }
+
+    public function testEnsureSyncFailsWhenHookIsRegisteredButNotUsed() : void
+    {
+        $tester = $this->buildTester();
+
+        $exitCode = $tester->execute([
+            '--config' => [__DIR__ . '/Fixtures/with-unused-hook.php'],
+            '--ensure-sync' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode, $tester->getDisplay());
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('unusedHookForTesting', $output);
+        self::assertStringContainsString('not used', $output);
+    }
+
+    private function buildTester() : CommandTester
+    {
+        $command = new Command('generate');
+        $command->setCode(new GenerateCommand(new Filesystem()));
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Console/Fixtures/with-only-used-hooks.php
+++ b/tests/Console/Fixtures/with-only-used-hooks.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+$hooksDir = dirname(__DIR__, 2) . '/Hooks';
+
+return Config::create(
+    schema: $hooksDir . '/Schema.graphql',
+    projectDir: dirname(__DIR__, 3),
+    outputDir: $hooksDir . '/Generated',
+    namespace: 'Ruudk\\GraphQLCodeGenerator\\Hooks\\Generated',
+    client: TestClient::class,
+)
+    ->withQueriesDir($hooksDir)
+    ->withHook(FindUserByIdHook::class);

--- a/tests/Console/Fixtures/with-unused-hook.php
+++ b/tests/Console/Fixtures/with-unused-hook.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\Console\UnusedHookForTesting;
+use Ruudk\GraphQLCodeGenerator\Hooks\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+$hooksDir = dirname(__DIR__, 2) . '/Hooks';
+
+return Config::create(
+    schema: $hooksDir . '/Schema.graphql',
+    projectDir: dirname(__DIR__, 3),
+    outputDir: $hooksDir . '/Generated',
+    namespace: 'Ruudk\\GraphQLCodeGenerator\\Hooks\\Generated',
+    client: TestClient::class,
+)
+    ->withQueriesDir($hooksDir)
+    ->withHook(FindUserByIdHook::class)
+    ->withHook(UnusedHookForTesting::class);

--- a/tests/Console/UnusedHookForTesting.php
+++ b/tests/Console/UnusedHookForTesting.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Console;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'unusedHookForTesting')]
+final readonly class UnusedHookForTesting
+{
+    public function __invoke(string $id) : string
+    {
+        return $id;
+    }
+}


### PR DESCRIPTION
Surface hooks that are registered via Config::withHook() but end up referenced by no generated code, so CI catches stale registrations instead of letting them rot. Emits one warning per unused hook and flips the exit code to 1.

Reuses ClassHookUsageRegistry — already populated by PlanExecutor as the authoritative "which hooks are actually wired into generated classes" set — via a new getAllUsedHookNames() union helper, rather than re-walking DataClassPlan instances from the command layer.

Covered by a CommandTester-driven test that wires the GenerateCommand invokable into a Symfony Command and asserts the success and unused-hook failure paths against fixture configs that reuse the existing Hooks/ test output.
