### PR TITLE
Add cloud setup script for Claude Code on the web

### DIFF
--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Cloud environment setup script for Claude Code on the web.
+# Paste the contents of this file into the "Setup script" field of your
+# environment at https://claude.ai/code (Add/Edit environment).
+#
+# The script runs once as root on Ubuntu 24.04, then the resulting
+# filesystem is snapshotted and reused for ~7 days, so subsequent
+# sessions start instantly with PHP 8.5 + vendor/ already in place.
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    software-properties-common \
+    unzip
+
+add-apt-repository -y ppa:ondrej/php
+apt-get update
+
+apt-get install -y --no-install-recommends \
+    php8.5-cli \
+    php8.5-curl \
+    php8.5-dom \
+    php8.5-intl \
+    php8.5-mbstring \
+    php8.5-tokenizer \
+    php8.5-xml \
+    php8.5-zip
+
+update-alternatives --set php /usr/bin/php8.5
+
+php -v
+composer --version
+
+composer install --no-interaction --prefer-dist --no-progress


### PR DESCRIPTION
## Summary
- Adds `.claude/setup.sh` so Claude Code on the web can build and run this project.
- Default cloud env ships PHP 8.4, but `composer.json` requires `php: ^8.5`. The script installs PHP 8.5 + needed extensions via `ppa:ondrej/php`, switches the `php` alternative, then runs `composer install`.
- Composer is already pre-installed in cloud sessions and runs against whichever `php` is selected, so no separate Composer install is needed.
- `.claude/` is already excluded from the Composer dist via the existing `* export-ignore` rule in `.gitattributes`, so nothing to change there.

## How to enable
Paste the contents of `.claude/setup.sh` into the **Setup script** field of the cloud environment at [claude.ai/code](https://claude.ai/code) (Add/Edit environment). It runs once as root on Ubuntu 24.04, then the resulting filesystem is snapshotted and reused for ~7 days, so subsequent sessions start instantly with PHP 8.5 and `vendor/` already in place.

## Test plan
- [ ] Paste `.claude/setup.sh` into the cloud env's Setup script field
- [ ] Start a new web session and confirm `php -v` reports 8.5.x
- [ ] Confirm `composer install` completes during setup (no missing extensions)
- [ ] Run `vendor/bin/phpunit` to verify the test suite executes
- [ ] Run `vendor/bin/phpstan analyse` to verify static analysis works

https://claude.ai/code/session_01MfgUPsG7odiK3EKpUdJdjf