### PR TITLE
Add Claude session start hook for composer dependency installation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+composer install --no-interaction --prefer-dist --no-progress

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Claude IDE integration hooks to automatically install PHP composer dependencies when starting a remote coding session.

## Key Changes
- Added `.claude/settings.json` configuration file that defines a `SessionStart` hook
- Added `.claude/hooks/session-start.sh` bash script that runs `composer install` during session initialization
- The hook only executes in remote coding environments (when `CLAUDE_CODE_REMOTE=true`)

## Implementation Details
- The session start hook is configured to run a shell command that installs composer dependencies with non-interactive mode and preferred distribution packages
- The script includes safety flags (`set -euo pipefail`) for robust error handling
- The hook gracefully exits early if not running in a remote environment, preventing unnecessary execution in local development setups

https://claude.ai/code/session_01DTjbHwms4TzU1Q6AtXPqqw