### PR TITLE
Fix Composer superuser mode and PHPStan error reporting

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,4 +7,4 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-composer install --no-interaction --prefer-dist --no-progress
+COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist --no-progress

--- a/tests/PHPStan/phpstan.neon
+++ b/tests/PHPStan/phpstan.neon
@@ -3,6 +3,7 @@ includes:
 
 parameters:
     level: max
+    reportUnmatchedIgnoredErrors: false
     paths:
         - Fixtures
 


### PR DESCRIPTION
## Summary
This PR addresses two configuration issues in the development environment setup and static analysis tooling.

## Key Changes
- **Composer superuser mode**: Added `COMPOSER_ALLOW_SUPERUSER=1` environment variable to the session start hook to allow Composer to run as root/superuser without warnings or errors. This is necessary when running in containerized environments.
- **PHPStan error reporting**: Disabled unmatched ignored errors reporting in PHPStan configuration by setting `reportUnmatchedIgnoredErrors: false`. This prevents false positives when baseline ignores are no longer needed.

## Implementation Details
- The Composer change ensures the installation process completes successfully in Docker/container environments where the process runs as root
- The PHPStan change reduces noise in static analysis by not reporting when ignore directives don't match any actual errors, which is useful during refactoring when baseline ignores may become obsolete

https://claude.ai/code/session_01P9dfXw8EMBTHvH9UWre9KP