### PR TITLE
Improve PHPStan test assertions with JSON output validation

### DIFF
--- a/tests/PHPStan/RestrictedUsageExtensionTest.php
+++ b/tests/PHPStan/RestrictedUsageExtensionTest.php
@@ -13,16 +13,54 @@ final class RestrictedUsageExtensionTest extends TestCase
     public function testExtension() : void
     {
         $command = sprintf(
-            '%s analyse --configuration=%s --no-progress --error-format=raw 2>&1',
+            '%s analyse --configuration=%s --no-progress --error-format=json 2>/dev/null',
             escapeshellarg(dirname(__DIR__, 2) . '/vendor/bin/phpstan'),
             escapeshellarg(__DIR__ . '/phpstan.neon'),
         );
 
-        exec($command, $output, $exitCode);
+        exec($command, $output);
 
-        self::assertSame(0, $exitCode, sprintf(
-            "PHPStan reported errors for tests/PHPStan fixtures.\n\nOutput:\n%s",
-            implode(PHP_EOL, $output),
-        ));
+        $actual = str_replace(__DIR__ . '/', '', implode("\n", $output));
+
+        self::assertJsonStringEqualsJsonString(
+            <<<'JSON'
+                {
+                    "totals": {"errors": 0, "file_errors": 4},
+                    "files": {
+                        "Fixtures/NotAllowedController.php": {
+                            "errors": 4,
+                            "messages": [
+                                {
+                                    "message": "Method execute from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeQuery is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
+                                    "line": 18,
+                                    "ignorable": true,
+                                    "identifier": "graphql.inline.method.restricted"
+                                },
+                                {
+                                    "message": "Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
+                                    "line": 19,
+                                    "ignorable": true,
+                                    "identifier": "new.graphql.inline.class.restricted"
+                                },
+                                {
+                                    "message": "Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
+                                    "line": 21,
+                                    "ignorable": true,
+                                    "identifier": "graphql.inline.property.restricted"
+                                },
+                                {
+                                    "message": "Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
+                                    "line": 21,
+                                    "ignorable": true,
+                                    "identifier": "graphql.inline.property.restricted"
+                                }
+                            ]
+                        }
+                    },
+                    "errors": []
+                }
+                JSON,
+            $actual,
+        );
     }
 }

--- a/tests/PHPStan/phpstan.neon
+++ b/tests/PHPStan/phpstan.neon
@@ -3,7 +3,6 @@ includes:
 
 parameters:
     level: max
-    reportUnmatchedIgnoredErrors: false
     paths:
         - Fixtures
 
@@ -17,20 +16,3 @@ parameters:
             identifier: shipmonk.deadMethod
             paths:
                 - Fixtures/*.php
-
-        # Expected restricted-usage errors from NotAllowedController. With
-        # reportUnmatchedIgnoredErrors (default true) the run fails if any
-        # pattern below stops matching — i.e. if the extension regresses and
-        # fails to emit one of the expected restricted-usage errors.
-        -
-            message: '#^Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
-            path: Fixtures/NotAllowedController.php
-            count: 1
-        -
-            message: '#^Method execute from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeQuery is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
-            path: Fixtures/NotAllowedController.php
-            count: 1
-        -
-            message: '#^Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController$#'
-            path: Fixtures/NotAllowedController.php
-            count: 2


### PR DESCRIPTION
## Summary
Refactored the PHPStan extension test to use JSON output format and explicit assertion validation instead of relying on exit codes and PHPStan configuration-based error matching.

## Key Changes
- Changed PHPStan output format from `raw` to `json` for structured error validation
- Replaced exit code assertion with explicit JSON schema validation using `assertJsonStringEqualsJsonString()`
- Removed `reportUnmatchedIgnoredErrors: false` configuration and all error ignore patterns from `phpstan.neon`
- Updated test to directly assert against expected error messages, line numbers, and identifiers in the JSON output
- Suppressed stderr output (`2>/dev/null`) since JSON format provides all necessary error information

## Implementation Details
The test now validates:
- Exact error count (4 errors in NotAllowedController.php)
- Specific error messages for each restricted usage violation
- Line numbers where violations occur
- Error identifiers (graphql.inline.method.restricted, new.graphql.inline.class.restricted, graphql.inline.property.restricted)
- Ignorability status of each error

This approach provides more robust testing by explicitly verifying the extension's output rather than relying on PHPStan's configuration-based error suppression mechanism.

https://claude.ai/code/session_01AUsh6FfvjTMqxeCq45ashJ