### PR TITLE
Emit hook inputs via public properties instead of $this->data

### DIFF
--- a/src/Executor/PlanExecutor.php
+++ b/src/Executor/PlanExecutor.php
@@ -100,8 +100,19 @@ final class PlanExecutor
     {
         $this->hookUsageRegistry->classHooks = [];
 
+        /**
+         * @var array<string, DataClassPlan> $plansByFqcn
+         */
+        $plansByFqcn = [];
+
         foreach ($plan->classes as $class) {
-            if ($class instanceof DataClassPlan && $class->usedHooks !== []) {
+            if ( ! $class instanceof DataClassPlan) {
+                continue;
+            }
+
+            $plansByFqcn[$class->fqcn] = $class;
+
+            if ($class->usedHooks !== []) {
                 $this->hookUsageRegistry->classHooks[$class->fqcn] = $class->usedHooks;
             }
         }
@@ -109,7 +120,7 @@ final class PlanExecutor
         $files = [];
 
         foreach ($plan->classes as $path => $class) {
-            $files[$path] = $this->generateClass($class);
+            $files[$path] = $this->generateClass($class, $plansByFqcn);
         }
 
         foreach ($plan->operations as $operation) {
@@ -183,12 +194,13 @@ final class PlanExecutor
     }
 
     /**
+     * @param array<string, DataClassPlan> $plansByFqcn
      * @throws LogicException
      */
-    private function generateClass(object $class) : string
+    private function generateClass(object $class, array $plansByFqcn) : string
     {
         return match ($class::class) {
-            DataClassPlan::class => $this->dataClassGenerator->generate($class),
+            DataClassPlan::class => $this->dataClassGenerator->generate($class, $plansByFqcn),
 
             EnumClassPlan::class => $this->enumTypeGenerator->generate($class),
 

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -48,7 +48,83 @@ final class DataClassGenerator extends AbstractGenerator
         return $result;
     }
 
-    public function generate(DataClassPlan $plan) : string
+    /**
+     * Walks a dotted `@hook` input path through the current class's field shape
+     * (and the nested classes referenced along the way), emitting a property-
+     * chain accessor like `$this->creator->id`. Nullable intermediates get
+     * promoted to `?->` so the chain's static type stays accurate.
+     *
+     * @param array<string, DataClassPlan> $plansByFqcn
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     */
+    private function buildHookInputAccessor(string $path, SymfonyType $fields, array $plansByFqcn) : string
+    {
+        $segments = explode('.', $path);
+        $accessor = '$this';
+        $chainNullable = false;
+        $shape = $this->unwrapShape($fields);
+
+        $last = count($segments) - 1;
+
+        foreach ($segments as $i => $segment) {
+            $shapeArray = $shape->getShape();
+
+            Assert::keyExists($shapeArray, $segment, sprintf(
+                'Hook input path "%s" references unknown field "%s".',
+                $path,
+                $segment,
+            ));
+
+            $segmentType = $shapeArray[$segment]['type'];
+
+            $accessor .= ($chainNullable ? '?->' : '->') . $segment;
+
+            if ($i === $last) {
+                break;
+            }
+
+            $isNullable = $segmentType instanceof SymfonyType\NullableType;
+            $naked = $isNullable ? $segmentType->getWrappedType() : $segmentType;
+
+            Assert::isInstanceOf($naked, SymfonyType\ObjectType::class, sprintf(
+                'Hook input path "%s" cannot descend through non-object segment "%s".',
+                $path,
+                $segment,
+            ));
+
+            $nextFqcn = $naked->getClassName();
+
+            Assert::keyExists($plansByFqcn, $nextFqcn, sprintf(
+                'Hook input path "%s" references class "%s" that has no generated plan.',
+                $path,
+                $nextFqcn,
+            ));
+
+            $shape = $this->unwrapShape($plansByFqcn[$nextFqcn]->fields);
+            $chainNullable = $chainNullable || $isNullable;
+        }
+
+        return $accessor;
+    }
+
+    /**
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     */
+    private function unwrapShape(SymfonyType $type) : ArrayShapeType
+    {
+        if ($type instanceof SymfonyType\NullableType) {
+            $type = $type->getWrappedType();
+        }
+
+        Assert::isInstanceOf($type, ArrayShapeType::class);
+
+        return $type;
+    }
+
+    /**
+     * @param array<string, DataClassPlan> $plansByFqcn
+     */
+    public function generate(DataClassPlan $plan, array $plansByFqcn = []) : string
     {
         $parentType = $plan->parentType;
         $fields = $plan->fields;
@@ -89,7 +165,7 @@ final class DataClassGenerator extends AbstractGenerator
 
         $generator = new CodeGenerator($namespace);
 
-        return $generator->dumpFile(function () use ($plan, $definitionNode, $parentType, $nodesType, $fqcn, $payloadShape, $isData, $fields, $possibleTypes, $generator, $inlineFragmentRequiredFields) {
+        return $generator->dumpFile(function () use ($plan, $definitionNode, $parentType, $nodesType, $fqcn, $payloadShape, $isData, $fields, $possibleTypes, $generator, $inlineFragmentRequiredFields, $plansByFqcn) {
             yield $this->dumpHeader();
             yield '';
 
@@ -131,7 +207,7 @@ final class DataClassGenerator extends AbstractGenerator
             $requiredFieldsMap = $inlineFragmentRequiredFields;
 
             yield $generator->indent(
-                function () use ($plan, $parentType, $nodesType, $possibleTypes, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap) {
+                function () use ($plan, $parentType, $nodesType, $possibleTypes, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap, $plansByFqcn) {
                     if ($possibleTypes !== []) {
                         yield from $generator->docComment('@var list<string>');
                         yield sprintf(
@@ -195,17 +271,11 @@ final class DataClassGenerator extends AbstractGenerator
                                     $this->dumpPHPType($fieldType, $generator->import(...)),
                                     $fieldName,
                                 );
-                                yield $generator->indent(function () use ($fieldType, $fieldName, $generator) {
+                                yield $generator->indent(function () use ($fieldType, $fieldName, $fields, $plansByFqcn, $generator) {
                                     $args = [];
 
                                     foreach ($fieldType->inputPaths as $path) {
-                                        $accessor = '$this->data';
-
-                                        foreach (explode('.', $path) as $segment) {
-                                            $accessor .= '[' . var_export($segment, true) . ']';
-                                        }
-
-                                        $args[] = $accessor;
+                                        $args[] = $this->buildHookInputAccessor($path, $fields, $plansByFqcn);
                                     }
 
                                     yield from $generator->wrap(

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
@@ -25,7 +25,7 @@ final class Project
     }
 
     public ?User $user {
-        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->creator->id);
     }
 
     /**

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
@@ -21,7 +21,7 @@ final class Project
     }
 
     public ?User $user {
-        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->creator->id);
     }
 
     /**

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
@@ -21,7 +21,7 @@ final class ProjectSummary
     }
 
     public ?User $user {
-        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->creator->id);
     }
 
     /**

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
@@ -22,7 +22,7 @@ final class Project
      * @var list<User>
      */
     public array $contributors {
-        get => $this->contributors ??= $this->hooks['findUsersByIds']->__invoke($this->data['contributorIds']);
+        get => $this->contributors ??= $this->hooks['findUsersByIds']->__invoke($this->contributorIds);
     }
 
     public string $name {

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
@@ -25,7 +25,7 @@ final class Project
     }
 
     public ?User $user {
-        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->data['creator']['id']);
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->creator->id);
     }
 
     /**


### PR DESCRIPTION
Replace raw payload indexing (e.g. $this->data['creator']['id']) with the equivalent property chain ($this->creator->id) so hook callers see the same typed, transformed values the generated class already exposes on the outside. This matters for paths like metadata.ticketIds where a scalar mapping (ID → TicketId) means the hook would otherwise receive untransformed strings the rest of the codebase never sees.

Implementation walks the path segment-by-segment: the current class's ArrayShapeType gives the first hop, and each object segment's FQCN is resolved against a plan-by-FQCN map threaded from PlanExecutor to descend into the next class's shape. Nullable intermediates get `?->` so static analysis stays honest.

Regenerate the five Hooks* test fixtures — a single getter line in each — confirming the substitution is mechanical.
