### PR TITLE
Add SomeFragment test fixture for Twig template restrictions

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,7 +3,9 @@ pre-commit:
   commands:
     ensure-sync:
       glob: "*.php"
-      run: bin/graphql-client-code-generator --config=examples/config.php --config=tests/config.php --ensure-sync
+      run: |
+        [ -f examples/schema.docs.graphql ] || curl -fsSL -o examples/schema.docs.graphql https://docs.github.com/public/fpt/schema.docs.graphql
+        bin/graphql-client-code-generator --config=examples/config.php --config=tests/config.php --ensure-sync
 
     sync-readme-examples:
       glob:

--- a/tests/PHPStan/Fixtures/AllowedController.php
+++ b/tests/PHPStan/Fixtures/AllowedController.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures;
 
 use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\Data;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeFragment;
 use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeQuery;
 
 /**
- * Source of the generated classes — every access below must be allowed.
+ * Source of the generated query — query/data accesses below must be allowed.
+ * SomeFragment originates from a Twig template, so touching it from this
+ * controller must still fire restriction errors.
  */
 final readonly class AllowedController
 {
@@ -17,7 +20,8 @@ final readonly class AllowedController
         $query = new SomeQuery('ruud');
         $data = $query->execute();
         $inline = new Data('inline');
+        $twig = new SomeFragment('from twig');
 
-        return $data->name . $inline->name;
+        return $data->name . $inline->name . $twig->title;
     }
 }

--- a/tests/PHPStan/Fixtures/NotAllowedController.php
+++ b/tests/PHPStan/Fixtures/NotAllowedController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ruudk\GraphQLCodeGenerator\PHPStan\Fixtures;
 
 use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\Data;
+use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeFragment;
 use Ruudk\GraphQLCodeGenerator\PHPStan\Generated\SomeQuery;
 
 /**
@@ -17,7 +18,8 @@ final readonly class NotAllowedController
         $query = new SomeQuery('ruud');
         $data = $query->execute();
         $inline = new Data('inline');
+        $twig = new SomeFragment('from twig');
 
-        return $data->name . $inline->name;
+        return $data->name . $inline->name . $twig->title;
     }
 }

--- a/tests/PHPStan/Generated/SomeFragment.php
+++ b/tests/PHPStan/Generated/SomeFragment.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHPStan\Generated;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+
+#[Generated(
+    source: 'tests/PHPStan/templates/_some_fragment.html.twig',
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class SomeFragment
+{
+    public function __construct(
+        public string $title,
+    ) {
+    }
+}

--- a/tests/PHPStan/RestrictedUsageExtensionTest.php
+++ b/tests/PHPStan/RestrictedUsageExtensionTest.php
@@ -25,32 +25,61 @@ final class RestrictedUsageExtensionTest extends TestCase
         self::assertJsonStringEqualsJsonString(
             <<<'JSON'
                 {
-                    "totals": {"errors": 0, "file_errors": 4},
+                    "totals": {"errors": 0, "file_errors": 8},
                     "files": {
+                        "Fixtures/AllowedController.php": {
+                            "errors": 2,
+                            "messages": [
+                                {
+                                    "message": "Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeFragment is only allowed to be used from within tests/PHPStan/templates/_some_fragment.html.twig",
+                                    "line": 23,
+                                    "ignorable": true,
+                                    "identifier": "new.graphql.inline.class.restricted"
+                                },
+                                {
+                                    "message": "Property title from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeFragment is only allowed to be used from within tests/PHPStan/templates/_some_fragment.html.twig",
+                                    "line": 25,
+                                    "ignorable": true,
+                                    "identifier": "graphql.inline.property.restricted"
+                                }
+                            ]
+                        },
                         "Fixtures/NotAllowedController.php": {
-                            "errors": 4,
+                            "errors": 6,
                             "messages": [
                                 {
                                     "message": "Method execute from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeQuery is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
-                                    "line": 18,
+                                    "line": 19,
                                     "ignorable": true,
                                     "identifier": "graphql.inline.method.restricted"
                                 },
                                 {
                                     "message": "Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
-                                    "line": 19,
+                                    "line": 20,
+                                    "ignorable": true,
+                                    "identifier": "new.graphql.inline.class.restricted"
+                                },
+                                {
+                                    "message": "Instantiation of Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeFragment is only allowed to be used from within tests/PHPStan/templates/_some_fragment.html.twig",
+                                    "line": 21,
                                     "ignorable": true,
                                     "identifier": "new.graphql.inline.class.restricted"
                                 },
                                 {
                                     "message": "Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
-                                    "line": 21,
+                                    "line": 23,
                                     "ignorable": true,
                                     "identifier": "graphql.inline.property.restricted"
                                 },
                                 {
                                     "message": "Property name from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\Data is only allowed to be used from within Ruudk\\GraphQLCodeGenerator\\PHPStan\\Fixtures\\AllowedController",
-                                    "line": 21,
+                                    "line": 23,
+                                    "ignorable": true,
+                                    "identifier": "graphql.inline.property.restricted"
+                                },
+                                {
+                                    "message": "Property title from Ruudk\\GraphQLCodeGenerator\\PHPStan\\Generated\\SomeFragment is only allowed to be used from within tests/PHPStan/templates/_some_fragment.html.twig",
+                                    "line": 23,
                                     "ignorable": true,
                                     "identifier": "graphql.inline.property.restricted"
                                 }


### PR DESCRIPTION
## Summary
This PR adds test coverage for GraphQL-generated classes that originate from Twig templates, ensuring that restriction rules are properly enforced even when accessing such classes from allowed contexts.

## Key Changes
- **New test fixture**: Added `SomeFragment` generated class with `restricted: true` and `restrictInstantiation: true` attributes, sourced from a Twig template (`_some_fragment.html.twig`)
- **Updated test expectations**: Modified `RestrictedUsageExtensionTest` to expect 8 file errors (up from 4) to account for new SomeFragment restriction violations
- **Enhanced test fixtures**: Updated both `AllowedController` and `NotAllowedController` to instantiate and use `SomeFragment`, demonstrating that:
  - `AllowedController` (the source of generated query classes) still cannot access Twig-sourced classes without triggering restrictions
  - `NotAllowedController` also triggers restrictions when accessing Twig-sourced classes
- **Improved documentation**: Updated `AllowedController` comments to clarify that it's the source of generated queries, not all generated classes
- **Build process enhancement**: Updated `lefthook.yaml` to ensure the GraphQL schema is downloaded before running code generation sync checks

## Notable Details
The test demonstrates that the restriction system correctly distinguishes between:
1. Classes generated from GraphQL queries (allowed in `AllowedController`)
2. Classes generated from Twig templates (restricted everywhere, including in `AllowedController`)

This validates that the `source` attribute in the `#[Generated]` annotation properly controls access restrictions based on origin.

https://claude.ai/code/session_01HoxDvGi2SWKK56sKHKBBNs