### PR TITLE
Exclude @hook fields from variant presence checks

### DIFF
--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -1142,6 +1142,12 @@ final class SelectionSetPlanner
     ) : void {
         foreach ($selectionSet->selections as $selection) {
             if ($selection instanceof FieldNode && $selection->name->value !== '__typename') {
+                // Hook fields are synthesized client-side and never present in the raw response,
+                // so they must not be used as presence guards for discriminating union/interface variants.
+                if ($this->directiveProcessor->getHookDirective($selection->directives) !== null) {
+                    continue;
+                }
+
                 $fieldName = $selection->alias->value ?? $selection->name->value;
 
                 if ( ! in_array($fieldName, $requiredFields, true)) {

--- a/tests/HooksInUnionVariant/FindUserByIdHook.php
+++ b/tests/HooksInUnionVariant/FindUserByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findUserById')]
+final readonly class FindUserByIdHook
+{
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private array $users = [],
+    ) {}
+
+    public function __invoke(string $id) : ?User
+    {
+        return $this->users[$id] ?? null;
+    }
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data\Thing;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    /**
+     * @var list<Thing>
+     */
+    public array $things {
+        get => $this->things ??= array_map(fn($item) => new Thing($item, $this->hooks), $this->data['things']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'things': list<array{
+     *         '__typename': string,
+     *         'id': string,
+     *         'realFieldA'?: string,
+     *         'realFieldB'?: string,
+     *     }>,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data\Thing\AsVariantA;
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data\Thing\AsVariantB;
+
+// This file was automatically generated and should not be edited.
+
+final class Thing
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public ?AsVariantA $asVariantA {
+        get {
+            if (isset($this->asVariantA)) {
+                return $this->asVariantA;
+            }
+
+            if ($this->data['__typename'] !== 'VariantA') {
+                return $this->asVariantA = null;
+            }
+
+            if (! array_key_exists('realFieldA', $this->data)) {
+                return $this->asVariantA = null;
+            }
+
+            return $this->asVariantA = new AsVariantA($this->data, $this->hooks);
+        }
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->asVariantA
+     */
+    public bool $isVariantA {
+        get => $this->isVariantA ??= $this->data['__typename'] === 'VariantA';
+    }
+
+    public ?AsVariantB $asVariantB {
+        get {
+            if (isset($this->asVariantB)) {
+                return $this->asVariantB;
+            }
+
+            if ($this->data['__typename'] !== 'VariantB') {
+                return $this->asVariantB = null;
+            }
+
+            if (! array_key_exists('realFieldB', $this->data)) {
+                return $this->asVariantB = null;
+            }
+
+            return $this->asVariantB = new AsVariantB($this->data);
+        }
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->asVariantB
+     */
+    public bool $isVariantB {
+        get => $this->isVariantB ??= $this->data['__typename'] === 'VariantB';
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     *     'id': string,
+     *     'realFieldA'?: string,
+     *     'realFieldB'?: string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data\Thing;
+
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\User;
+
+// This file was automatically generated and should not be edited.
+
+final class AsVariantA
+{
+    /**
+     * @var list<string>
+     */
+    public const array POSSIBLE_TYPES = ['VariantA'];
+
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $realFieldA {
+        get => $this->realFieldA ??= $this->data['realFieldA'];
+    }
+
+    public ?User $user {
+        get => $this->user ??= $this->hooks['findUserById']->__invoke($this->id);
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'VariantA',
+     *     'id': string,
+     *     'realFieldA': string,
+     * } $data
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Data\Thing;
+
+// This file was automatically generated and should not be edited.
+
+final class AsVariantB
+{
+    /**
+     * @var list<string>
+     */
+    public const array POSSIBLE_TYPES = ['VariantB'];
+
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $realFieldB {
+        get => $this->realFieldB ??= $this->data['realFieldB'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'VariantB',
+     *     'id': string,
+     *     'realFieldB': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Error.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\FindUserByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          things {
+            __typename
+            id
+            ... on VariantA {
+              realFieldA
+            }
+            ... on VariantB {
+              realFieldB
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findUserById': FindUserByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        private array $hooks,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksInUnionVariant/HooksInUnionVariantTest.php
+++ b/tests/HooksInUnionVariant/HooksInUnionVariantTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\TestQuery;
+
+final class HooksInUnionVariantTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->withHook(FindUserByIdHook::class);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testHookFieldIsNotUsedAsVariantDiscriminator() : void
+    {
+        $findUserById = new FindUserByIdHook([
+            'thing-a' => new User('thing-a', 'https://example.com/avatars/a.png'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient([
+                'data' => [
+                    'things' => [
+                        [
+                            '__typename' => 'VariantA',
+                            'id' => 'thing-a',
+                            'realFieldA' => 'hello',
+                        ],
+                        [
+                            '__typename' => 'VariantB',
+                            'id' => 'thing-b',
+                            'realFieldB' => 'world',
+                        ],
+                    ],
+                ],
+            ]),
+            [
+                'findUserById' => $findUserById,
+            ],
+        )->execute();
+
+        [$first, $second] = $result->things;
+
+        self::assertNotNull($first->asVariantA);
+        self::assertSame('hello', $first->asVariantA->realFieldA);
+        self::assertNotNull($first->asVariantA->user);
+        self::assertSame('thing-a', $first->asVariantA->user->id);
+        self::assertSame('https://example.com/avatars/a.png', $first->asVariantA->user->avatar);
+        self::assertNull($first->asVariantB);
+
+        self::assertNull($second->asVariantA);
+        self::assertNotNull($second->asVariantB);
+        self::assertSame('world', $second->asVariantB->realFieldB);
+    }
+}

--- a/tests/HooksInUnionVariant/Schema.graphql
+++ b/tests/HooksInUnionVariant/Schema.graphql
@@ -1,0 +1,17 @@
+type Query {
+    things: [Thing!]!
+}
+
+interface Thing {
+    id: ID!
+}
+
+type VariantA implements Thing {
+    id: ID!
+    realFieldA: String!
+}
+
+type VariantB implements Thing {
+    id: ID!
+    realFieldB: String!
+}

--- a/tests/HooksInUnionVariant/Test.graphql
+++ b/tests/HooksInUnionVariant/Test.graphql
@@ -1,0 +1,13 @@
+query Test {
+    things {
+        __typename
+        id
+        ... on VariantA {
+            realFieldA
+            user @hook(name: "findUserById", input: ["id"])
+        }
+        ... on VariantB {
+            realFieldB
+        }
+    }
+}

--- a/tests/HooksInUnionVariant/User.php
+++ b/tests/HooksInUnionVariant/User.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant;
+
+final readonly class User
+{
+    public function __construct(
+        public string $id,
+        public string $avatar,
+    ) {}
+}


### PR DESCRIPTION
`@hook` selections are synthesized client-side and never appear in the raw GraphQL response. The parent wrapper's `as<Variant>` accessor generated an `array_key_exists(<hookField>, $this->data)` guard for every selection inside a union/interface variant, including hook fields — so the guard always failed and the accessor always returned `null`, silently dropping the variant for every response.

Fix by skipping hook-annotated selections in `SelectionSetPlanner::collectRequiredFieldsFromSelectionSet`, so the parent discriminator and the variant's `\$data` phpdoc shape agree on which selections are real response keys.
