### PR TITLE
Consolidate PHPUnit strict mode configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,11 +4,10 @@
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
+         beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
-         displayDetailsOnPhpunitDeprecations="true"
-         failOnPhpunitDeprecation="true"
-         failOnRisky="true"
-         failOnWarning="true">
+         failOnAllIssues="true"
+         displayDetailsOnAllIssues="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>


### PR DESCRIPTION
## Summary
Streamlined the PHPUnit configuration by consolidating multiple strict mode settings into more modern, unified options.

## Key Changes
- Added `beStrictAboutChangesToGlobalState="true"` to catch unintended global state modifications
- Replaced individual strict settings (`failOnPhpunitDeprecation`, `failOnRisky`, `failOnWarning`) with `failOnAllIssues="true"` for comprehensive issue detection
- Replaced `displayDetailsOnPhpunitDeprecations="true"` with `displayDetailsOnAllIssues="true"` for consistent error reporting across all issue types
- Kept `beStrictAboutOutputDuringTests="true"` as it addresses a specific concern

## Implementation Details
This change modernizes the PHPUnit configuration to use the newer consolidated options (`failOnAllIssues` and `displayDetailsOnAllIssues`) which provide equivalent or better coverage than the previous granular settings, while also adding stricter global state validation. The configuration now maintains the same level of test rigor with cleaner, more maintainable settings.

https://claude.ai/code/session_011SASX4ZyBXWfV2VToWCmfV