### PR TITLE
Drop fragment-field hoisting and update sebastian/diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,14 +788,6 @@ use Ruudk\GraphQLCodeGenerator\Fragments\Generated\Fragment\ProjectView;
 
 final class Project
 {
-    public ?string $description {
-        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
-    }
-
-    public string $name {
-        get => $this->name ??= $this->data['name'];
-    }
-
     public ProjectView $projectView {
         get => $this->projectView ??= new ProjectView($this->data);
     }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1.18",
         "ruudk/code-generator": "^0.4.7",
-        "sebastian/diff": "^8.1",
+        "sebastian/diff": "^7 || ^8",
         "symfony/console": "^8.0",
         "symfony/filesystem": "^8.0",
         "symfony/finder": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b277dd228a4bfa51ade1105f8d371175",
+    "content-hash": "635f6b064323c37a2d85ea8f1f832131",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -8062,5 +8062,5 @@
         "composer-runtime-api": "^2.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -556,7 +556,6 @@ final class Planner
                 $this->config->outputDir . '/Fragment/' . $name,
                 $fqcn,
                 'fragment',
-                isGeneratingTopLevelFragment: true,
             );
 
             $planner->setFragmentPayloadShape($name, $planResult->payloadShape);

--- a/src/Planner/FieldCollection.php
+++ b/src/Planner/FieldCollection.php
@@ -41,12 +41,4 @@ final class FieldCollection
     {
         return clone $this;
     }
-
-    /**
-     * @return array<string, SymfonyType>
-     */
-    public function getFields() : array
-    {
-        return $this->fields;
-    }
 }

--- a/src/Planner/PlanningContext.php
+++ b/src/Planner/PlanningContext.php
@@ -21,8 +21,6 @@ final readonly class PlanningContext
         public string $path,
         public ?array $indexByType = null,
         public array $indexBy = [],
-        public bool $isGeneratingTopLevelFragment = false,
-        public bool $isInsideFragmentContext = false,
     ) {}
 
     public function withPath(string $path) : self
@@ -39,7 +37,6 @@ final readonly class PlanningContext
             'fqcn' => $this->fqcn . '\\' . $className,
             'indexByType' => null,
             'indexBy' => [],
-            'isGeneratingTopLevelFragment' => false,
         ]);
     }
 

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -65,11 +65,6 @@ final class SelectionSetPlanner
     public private(set) array $inlineFragmentRequiredFields = [];
 
     /**
-     * @var array<string, SelectionSetResult> Fragment name to selection set result mapping
-     */
-    public private(set) array $fragmentSelectionResults = [];
-
-    /**
      * @var array<string, array{FragmentDefinitionNodeWithSource, list<string>}> Fragment name to definition mapping
      */
     public private(set) array $fragmentDefinitions = [];
@@ -104,7 +99,6 @@ final class SelectionSetPlanner
         ?bool $nullable = null,
         ?array $indexByType = null,
         array $indexBy = [],
-        bool $isGeneratingTopLevelFragment = false,
     ) : SelectionSetPlanResult {
         $context = new PlanningContext(
             outputDirectory: $outputDirectory,
@@ -112,8 +106,6 @@ final class SelectionSetPlanner
             path: $path,
             indexByType: $indexByType,
             indexBy: $indexBy,
-            isGeneratingTopLevelFragment: $isGeneratingTopLevelFragment,
-            isInsideFragmentContext: $isGeneratingTopLevelFragment, // If we're generating a fragment, we're in fragment context
         );
 
         $result = $this->planSelectionSet(
@@ -123,17 +115,6 @@ final class SelectionSetPlanner
             $context,
             $nullable,
         );
-
-        // Store fragment results for later use
-        // Only cache results from top-level fragment generation to ensure clean, unmerged results
-        if ($path === 'fragment' && $isGeneratingTopLevelFragment && str_contains($fqcn, '\\Fragment\\')) {
-            // Extract fragment name from FQCN
-            $parts = explode('\\', $fqcn);
-            $fragmentName = end($parts);
-
-            // Store the fragment result
-            $this->fragmentSelectionResults[$fragmentName] = $result;
-        }
 
         return new SelectionSetPlanResult(
             fields: $result->fields->toArrayShape(),
@@ -669,91 +650,6 @@ final class SelectionSetPlanner
             if ($requiredFields !== []) {
                 $this->inlineFragmentRequiredFields[$fragmentObjectType->getClassName()] = $requiredFields;
             }
-        }
-
-        // Only merge fragment fields when:
-        // 1. We're NOT generating a top-level fragment itself (to avoid fragments affecting each other)
-        // 2. The fragment is on the SAME type as the parent (not a conditional fragment)
-        // 3. There are other direct fields selected
-        // 4. We have the fragment result available
-        // Check if fragment type matches parent type
-        // This handles both object types and interfaces
-        // $fragmentType is already typed as Type&NamedType
-        $isFragmentOnSameType = false;
-
-        if ($parent instanceof NamedType) {
-            $isFragmentOnSameType = $parent->name() === $fragmentType->name();
-        }
-
-        $hasDirectFields = false;
-        $currentFields = $fields->getFields();
-        foreach ($currentFields as $name => $type) {
-            if ( ! str_starts_with($name, 'as') && $name !== '__typename') {
-                $hasDirectFields = true;
-
-                break;
-            }
-        }
-
-        // Fragment field merging is context-dependent:
-        // - In fragment context: strict isolation (no merging)
-        // - In query context with same type AND no conflicting direct selections: merge for convenience
-        // - When there are ANY direct field selections, maintain isolation per SPEC.md principle #3
-        $hasAnyDirectFields = false;
-        foreach ($fields->getFields() as $fName => $fType) {
-            // Skip special fields and fragment accessors
-            // TODO This is fragile, breaks easily
-            if ($fName === '__typename' || str_starts_with($fName, 'as') || str_starts_with($fName, 'is')) {
-                continue;
-            }
-
-            $nakedType = $this->typeMapper->getNakedType($fType);
-
-            if ( ! $nakedType instanceof FragmentObjectType) {
-                $hasAnyDirectFields = true;
-
-                break;
-            }
-        }
-
-        if ($isFragmentOnSameType && ! $context->isInsideFragmentContext && ! $hasAnyDirectFields && isset($this->fragmentSelectionResults[$selection->name->value])) {
-            $fragmentResult = $this->fragmentSelectionResults[$selection->name->value];
-            $fragmentFields = $fragmentResult->fields->getFields();
-
-            // Merge fragment fields directly into the parent for direct access
-            $currentFields = $fields->getFields();
-            foreach ($fragmentFields as $fragmentFieldName => $fragmentFieldType) {
-                // Skip the fragment wrapper field itself
-                if ($fragmentFieldName === $fieldName) {
-                    continue;
-                }
-
-                // Get the naked type to check what kind of field this is
-                $nakedType = $this->typeMapper->getNakedType($fragmentFieldType);
-
-                // Skip fragment accessors (both inline and named)
-                if ($nakedType instanceof FragmentObjectType) {
-                    continue;
-                }
-
-                // Skip boolean helper properties for fragments
-                // Check if the type is boolean using TypeIdentifier
-                // TODO This is fragile, breaks easily
-                if (str_starts_with($fragmentFieldName, 'is') && $fragmentFieldType->isIdentifiedBy(\Symfony\Component\TypeInfo\TypeIdentifier::BOOL)) {
-                    continue;
-                }
-
-                // Skip if field already exists (direct selection takes precedence)
-                if (isset($currentFields[$fragmentFieldName])) {
-                    continue;
-                }
-
-                // Add the field for direct access
-                $fields->add($fragmentFieldName, $fragmentFieldType);
-            }
-
-            // Merge path fields from fragment
-            $pathFields->merge($fragmentResult->pathFields);
         }
 
         // Note: PayloadShapeBuilder already handles merging fields from fragment spreads

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -126,13 +126,4 @@ final readonly class TypeMapper
 
         return SymfonyType::mixed();
     }
-
-    public function getNakedType(SymfonyType $type) : SymfonyType
-    {
-        if ($type instanceof SymfonyType\NullableType) {
-            return $type->getWrappedType();
-        }
-
-        return $type;
-    }
 }

--- a/tests/Fragments/FragmentsTest.php
+++ b/tests/Fragments/FragmentsTest.php
@@ -33,6 +33,7 @@ final class FragmentsTest extends GraphQLTestCase
             ],
         ]))->execute();
 
+        self::assertSame('User', $result->viewer->__typename);
         self::assertNotNull($result->viewer->viewerName);
         self::assertTrue($result->viewer->isViewerName);
         self::assertSame('Ruud Kamphuis', $result->viewer->viewerName->name);

--- a/tests/Fragments/Generated/Query/Test/Data/Project.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Project.php
@@ -10,14 +10,6 @@ use Ruudk\GraphQLCodeGenerator\Fragments\Generated\Fragment\ProjectView;
 
 final class Project
 {
-    public ?string $description {
-        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
-    }
-
-    public string $name {
-        get => $this->name ??= $this->data['name'];
-    }
-
     public ProjectView $projectView {
         get => $this->projectView ??= new ProjectView($this->data);
     }

--- a/tests/Fragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Viewer.php
@@ -46,10 +46,6 @@ final class Viewer
         get => $this->isApplicationDetails ??= $this->data['__typename'] === 'Application';
     }
 
-    public string $name {
-        get => $this->name ??= $this->data['name'];
-    }
-
     public ?UserDetails $userDetails {
         get {
             if (isset($this->userDetails)) {

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
@@ -11,10 +11,6 @@ use Ruudk\GraphQLCodeGenerator\HooksWithFragmentSpread\Generated\Fragment\Projec
 
 final class Project
 {
-    public ?string $description {
-        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : null;
-    }
-
     public ProjectListing $projectListing {
         get => $this->projectListing ??= new ProjectListing($this->data, $this->hooks);
     }

--- a/tests/HooksWithFragmentSpread/HooksWithFragmentSpreadTest.php
+++ b/tests/HooksWithFragmentSpread/HooksWithFragmentSpreadTest.php
@@ -117,6 +117,7 @@ final class HooksWithFragmentSpreadTest extends GraphQLTestCase
 
         [$first, $second] = $result->viewer->projects;
 
+        self::assertNull($first->projectListing->description);
         self::assertSame('GraphQL Code Generator', $first->projectListing->projectSummary->name);
         self::assertNotNull($first->projectListing->projectSummary->user);
         self::assertSame('user-123', $first->projectListing->projectSummary->user->id);

--- a/tests/Planner/SelectionSetPlannerTest.php
+++ b/tests/Planner/SelectionSetPlannerTest.php
@@ -110,7 +110,6 @@ final class SelectionSetPlannerTest extends TestCase
             '/tmp/generated/Fragment/ItemWithDetails',
             'Test\\Generated\\Fragment\\ItemWithDetails',
             'fragment',
-            isGeneratingTopLevelFragment: true,
         );
         // Find the Detail class plan in the result
         $detailClassPlan = null;
@@ -229,7 +228,6 @@ final class SelectionSetPlannerTest extends TestCase
             '/tmp/generated/Fragment/PaymentDetails',
             'Test\\Generated\\Fragment\\PaymentDetails',
             'fragment',
-            isGeneratingTopLevelFragment: true,
         );
         // Find the Payout class plan in the result
         $payoutClassPlan = null;

--- a/tests/Twig/Generated/Query/Projectsd4cba6/Data.php
+++ b/tests/Twig/Generated/Query/Projectsd4cba6/Data.php
@@ -6,8 +6,6 @@ namespace Ruudk\GraphQLCodeGenerator\Twig\Generated\Query\Projectsd4cba6;
 
 use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
 use Ruudk\GraphQLCodeGenerator\Twig\Generated\Fragment\AdminProjectList;
-use Ruudk\GraphQLCodeGenerator\Twig\Generated\Fragment\AdminProjectList\Project;
-use Ruudk\GraphQLCodeGenerator\Twig\Generated\Fragment\AdminProjectList\Viewer;
 use Ruudk\GraphQLCodeGenerator\Twig\SomeController;
 
 // This file was automatically generated and should not be edited.
@@ -21,17 +19,6 @@ final class Data
 {
     public AdminProjectList $adminProjectList {
         get => $this->adminProjectList ??= new AdminProjectList($this->data);
-    }
-
-    /**
-     * @var list<Project>
-     */
-    public array $projects {
-        get => $this->projects ??= array_map(fn($item) => new Project($item), $this->data['projects']);
-    }
-
-    public Viewer $viewer {
-        get => $this->viewer ??= new Viewer($this->data['viewer']);
     }
 
     /**


### PR DESCRIPTION
### Drop fragment-field hoisting from generated data classes

Previously, when a selection set consisted only of fragment spreads (e.g. `query Projects { ...AdminProjectList }`), the generator hoisted every non-fragment field from the spread into the parent Data class alongside the fragment accessor. That meant the same data was reachable two ways — `$data->viewer` and `$data->adminProjectList->viewer` — which bloated generated output, muddled intent, and created dead properties for Twig or restricted consumers that only reach for the fragment accessor.

Remove the merge in `SelectionSetPlanner::processFragmentSpread` so fragment fields are only exposed via the fragment accessor. Every field now has a single canonical path that mirrors how the query was written. Along the way, drop the now-unused `fragmentSelectionResults` cache, `PlanningContext::$isInsideFragmentContext`, the `isGeneratingTopLevelFragment` plan() parameter, `FieldCollection::getFields`, and `TypeMapper::getNakedType`.

### Allow sebastian/diff v7 and v8
