### PR TITLE
Add #[GeneratedGraphQLFragment] for service-owned data contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
         with:
           dependency-versions: ${{ matrix.dependency-versions }}
 
@@ -68,7 +68,7 @@ jobs:
         run: composer validate --strict
 
       - name: Install dependencies
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
 
       - name: Check composer.json normalization
         run: composer normalize --diff --dry-run

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ enum SearchType: string
 - **Schema introspection** with auto-update from live endpoints
 - **Custom scalar mapping** (DateTime, JSON, UUID, etc.)
 - **Inline operations** - define GraphQL directly in PHP classes
+- **Inline fragments** - services publish their data contract via `#[GeneratedGraphQLFragment]`
 - **Twig template extraction** - extract fragments from Twig files
 - **Namespace customization** - organize generated code your way
 
@@ -472,6 +473,98 @@ final readonly class SomeController
 4. Commit the generated code—now your CI can verify the query class exists and matches
 
 **No separate `.graphql` files needed**—your GraphQL lives right next to where it's used, but you still get full type safety and validation!
+
+### 🧩 Inline GraphQL Fragments
+
+A service that operates on a slice of data can **publish its own data contract** as a fragment via `#[GeneratedGraphQLFragment]`. Callers spread the fragment into their queries and hand the resulting typed object back to the service — without having to know which fields the service reads internally.
+
+<!-- source: tests/InlineFragment/UserMapper.php -->
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLFragment;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Fragment\UserName56995d\UserName;
+
+final readonly class UserMapper
+{
+    private const string FRAGMENT = <<<'GRAPHQL'
+        fragment UserName on User {
+            id
+            firstName
+            lastName
+        }
+        GRAPHQL;
+
+    /**
+     * @param list<UserName> $users
+     * @return list<string>
+     */
+    public function mapMany(
+        #[GeneratedGraphQLFragment(self::FRAGMENT)]
+        array $users,
+    ) : array {
+        return array_map(
+            fn(UserName $u) => $u->firstName . ' ' . $u->lastName,
+            $users,
+        );
+    }
+}
+```
+
+**Multiple consumers spread the same fragment:**
+
+<!-- source: tests/InlineFragment/ListUsersClient.php -->
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe\ListUsersQuery;
+
+final readonly class ListUsersClient
+{
+    private const string OPERATION = <<<'GRAPHQL'
+        query ListUsers {
+            users {
+                ...UserName
+            }
+        }
+        GRAPHQL;
+
+    public function __construct(
+        #[GeneratedGraphQLClient(self::OPERATION)]
+        private ListUsersQuery $query,
+        private UserMapper $mapper,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function getDisplayNames() : array
+    {
+        return $this->mapper->mapMany(
+            array_map(fn($user) => $user->userName, $this->query->execute()->users),
+        );
+    }
+}
+```
+
+**How it works:**
+
+1. The service tags a method parameter with `#[GeneratedGraphQLFragment(self::FRAGMENT)]`.
+2. The generator emits the fragment class at `Generated/Fragment/{Name}{hash}/{Name}.php` — hashed by the declaration site, like `#[GeneratedGraphQLClient]`.
+3. The fragment class is stamped with `#[Generated(source: …, restricted: true, restrictInstantiation: true)]`, so PHPStan only lets the declaring service consume it.
+4. Any query — `.graphql` file, Twig block, or another inline `#[GeneratedGraphQLClient]` — can spread `...UserName`; the generated Data class imports the same hashed fragment class.
+5. Callers hand fragment-shaped data back to the service, which is the only place allowed to read it.
+
+**Fragment names must be globally unique** across `.graphql` files, Twig templates, and PHP attributes — the generator throws on conflict, naming both source locations.
 
 ### 🎭 Twig Template Support
 

--- a/src/Attribute/GeneratedGraphQLFragment.php
+++ b/src/Attribute/GeneratedGraphQLFragment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final readonly class GeneratedGraphQLFragment
+{
+    public function __construct(
+        public string $fragment,
+    ) {}
+}

--- a/src/GraphQL/DocumentNodeWithSource.php
+++ b/src/GraphQL/DocumentNodeWithSource.php
@@ -8,14 +8,15 @@ use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\NodeList;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineFragmentSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 
 final class DocumentNodeWithSource extends DocumentNode
 {
-    public GraphQLFileSource | InlineSource | TwigFileSource $source;
+    public GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source;
 
-    public static function create(DocumentNode $documentNode, GraphQLFileSource | InlineSource | TwigFileSource $source) : self
+    public static function create(DocumentNode $documentNode, GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source) : self
     {
         $definitions = [];
         foreach ($documentNode->definitions as $definition) {

--- a/src/GraphQL/FragmentDefinitionNodeWithSource.php
+++ b/src/GraphQL/FragmentDefinitionNodeWithSource.php
@@ -6,14 +6,15 @@ namespace Ruudk\GraphQLCodeGenerator\GraphQL;
 
 use GraphQL\Language\AST\FragmentDefinitionNode;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineFragmentSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 
 final class FragmentDefinitionNodeWithSource extends FragmentDefinitionNode
 {
-    public GraphQLFileSource | InlineSource | TwigFileSource $source;
+    public GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source;
 
-    public static function create(FragmentDefinitionNode $fragmentNode, GraphQLFileSource | InlineSource | TwigFileSource $source) : self
+    public static function create(FragmentDefinitionNode $fragmentNode, GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source) : self
     {
         return new self([
             'name' => $fragmentNode->name,

--- a/src/PHP/Visitor/FragmentFinder.php
+++ b/src/PHP/Visitor/FragmentFinder.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLFragment;
+
+final class FragmentFinder extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, array<string, array<string, string>>>
+     */
+    public private(set) array $fragments = [];
+    private ?string $className = null;
+
+    /**
+     * @param array<string, String_> $constants
+     */
+    public function __construct(
+        private array $constants,
+    ) {}
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Override]
+    public function enterNode(Node $node) : null
+    {
+        if ($node instanceof Node\Stmt\Class_ && $node->name !== null) {
+            $this->className = $node->namespacedName?->toString();
+
+            return null;
+        }
+
+        if ( ! $node instanceof Node\Stmt\ClassMethod) {
+            return null;
+        }
+
+        if ($this->className === null) {
+            return null;
+        }
+
+        foreach ($node->params as $param) {
+            if ( ! $param->var instanceof Node\Expr\Variable) {
+                continue;
+            }
+
+            if ( ! is_string($param->var->name)) {
+                continue;
+            }
+
+            foreach ($param->attrGroups as $attrGroup) {
+                foreach ($attrGroup->attrs as $attr) {
+                    if ($attr->name->toString() !== GeneratedGraphQLFragment::class) {
+                        continue;
+                    }
+
+                    if (count($attr->args) !== 1) {
+                        continue;
+                    }
+
+                    $arg = $attr->args[0];
+
+                    $value = $arg->value;
+
+                    if ($value instanceof Node\Expr\ClassConstFetch && $value->name instanceof Node\Identifier) {
+                        $value = $this->constants[$value->name->toString()];
+                    }
+
+                    if ( ! $value instanceof String_) {
+                        throw new InvalidArgumentException('Invalid argument type');
+                    }
+
+                    $this->fragments[$this->className][$node->name->toString()][$param->var->name] = $value->value;
+
+                    continue 3;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    #[Override]
+    public function leaveNode(Node $node) : null
+    {
+        if ( ! $node instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
+        $this->className = null;
+
+        return null;
+    }
+}

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -65,6 +65,7 @@ use Ruudk\GraphQLCodeGenerator\GraphQL\DocumentNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\PossibleTypesFinder;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\ClassConstantFinder;
+use Ruudk\GraphQLCodeGenerator\PHP\Visitor\FragmentFinder;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\OperationFinder;
 use Ruudk\GraphQLCodeGenerator\Planner\OperationPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
@@ -77,6 +78,7 @@ use Ruudk\GraphQLCodeGenerator\Planner\Plan\OperationClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
 use Ruudk\GraphQLCodeGenerator\Planner\SelectionSetPlanner;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineFragmentSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLExtension;
@@ -271,7 +273,7 @@ final class Planner
                 ->files()
                 ->in($this->config->inlineProcessingDirectories)
                 ->name('*.php')
-                ->contains(GeneratedGraphQLClient::class);
+                ->contains('/GeneratedGraphQL(?:Client|Fragment)/');
 
             foreach ($finder as $file) {
                 $stmts = $this->phpParser->parse($this->filesystem->readFile($file->getPathname()));
@@ -319,6 +321,65 @@ final class Planner
                                 $document,
                                 new InlineSource(
                                     $className,
+                                    $shortHash,
+                                ),
+                            );
+                        }
+                    }
+                }
+
+                $fragmentFinder = new FragmentFinder($classConstants->constants);
+                new NodeTraverser($fragmentFinder)->traverse($stmts);
+
+                foreach ($fragmentFinder->fragments as $className => $methods) {
+                    foreach ($methods as $method => $properties) {
+                        foreach ($properties as $property => $fragmentString) {
+                            $hash = hash('sha256', implode(',', [
+                                $className,
+                                $method,
+                                $property,
+                            ]));
+                            $shortHash = substr($hash, 0, 6);
+
+                            $document = Parser::parse($fragmentString);
+                            Assert::count($document->definitions, 1, sprintf(
+                                'Expected %s::%s::$%s to declare exactly one fragment.',
+                                $className,
+                                $method,
+                                $property,
+                            ));
+
+                            [$definition] = $document->definitions;
+                            Assert::isInstanceOf($definition, FragmentDefinitionNode::class, sprintf(
+                                'Expected %s::%s::$%s to declare a fragment definition.',
+                                $className,
+                                $method,
+                                $property,
+                            ));
+
+                            $name = $definition->name->value;
+
+                            if (isset($definedFragments[$name])) {
+                                throw new Exception(sprintf(
+                                    'Class "%s::%s::$%s" defined fragment "%s" but it is already defined in "%s".',
+                                    $className,
+                                    $method,
+                                    $property,
+                                    $name,
+                                    $definedFragments[$name],
+                                ));
+                            }
+
+                            $definedFragments[$name] = sprintf('%s::%s::$%s', $className, $method, $property);
+
+                            $usedTypesCollector->analyze($document);
+
+                            $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
+                                $document,
+                                new InlineFragmentSource(
+                                    $className,
+                                    $method,
+                                    $property,
                                     $shortHash,
                                 ),
                             );
@@ -504,7 +565,10 @@ final class Planner
          * @var list<array{
          *     name: string,
          *     fragment: FragmentDefinitionNodeWithSource,
-         *     type: NamedType&Type
+         *     type: NamedType&Type,
+         *     fqcn: string,
+         *     path: string,
+         *     nestedDir: string,
          * }> $fragmentsToProcess
          */
         $fragmentsToProcess = [];
@@ -531,7 +595,20 @@ final class Planner
 
             Assert::notNull($type, 'Fragment type is expected');
 
+            if ($fragment->source instanceof InlineFragmentSource) {
+                $namespacedName = sprintf('%s%s', $name, $fragment->source->hash);
+                $fqcn = $this->fullyQualified('Fragment', $namespacedName, $name);
+                $fragmentDir = $this->config->outputDir . '/Fragment/' . $namespacedName;
+                $path = $fragmentDir . '/' . $name . '.php';
+                $nestedDir = $fragmentDir . '/' . $name;
+            } else {
+                $fqcn = $this->fullyQualified('Fragment', $name);
+                $path = $this->config->outputDir . '/Fragment/' . $name . '.php';
+                $nestedDir = $this->config->outputDir . '/Fragment/' . $name;
+            }
+
             $planner->setFragmentType($name, $type);
+            $planner->setFragmentFqcn($name, $fqcn);
             $planner->setFragmentDefinition($name, $fragment, UsedFragmentsVisitor::getUsedFragments($fragment));
 
             // Store for processing after all are set
@@ -539,6 +616,9 @@ final class Planner
                 'name' => $name,
                 'fragment' => $fragment,
                 'type' => $type,
+                'fqcn' => $fqcn,
+                'path' => $path,
+                'nestedDir' => $nestedDir,
             ];
         }
 
@@ -547,13 +627,15 @@ final class Planner
             $name = $fragmentData['name'];
             $fragment = $fragmentData['fragment'];
             $type = $fragmentData['type'];
+            $fqcn = $fragmentData['fqcn'];
+            $path = $fragmentData['path'];
+            $nestedDir = $fragmentData['nestedDir'];
 
-            $fqcn = $this->fullyQualified('Fragment', $name);
             $planResult = $planner->plan(
                 $fragment->source,
                 $fragment->selectionSet,
                 $type,
-                $this->config->outputDir . '/Fragment/' . $name,
+                $nestedDir,
                 $fqcn,
                 'fragment',
             );
@@ -561,7 +643,6 @@ final class Planner
             $planner->setFragmentPayloadShape($name, $planResult->payloadShape);
 
             // Add the fragment class itself
-            $path = $this->config->outputDir . '/Fragment/' . $name . '.php';
             $result->addClass(new DataClassPlan(
                 $fragment->source,
                 $path,
@@ -755,6 +836,10 @@ final class Planner
 
         if ($document->source instanceof TwigFileSource) {
             throw new Exception('Twig templates may only contain fragment definitions');
+        }
+
+        if ($document->source instanceof InlineFragmentSource) {
+            throw new Exception('Inline fragment attributes may only declare fragment definitions');
         }
 
         $source = $document->source;

--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -10,6 +10,7 @@ use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\Type;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineFragmentSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
@@ -29,7 +30,7 @@ final class DataClassPlan
      * @param array<string, list<string>> $inlineFragmentRequiredFields
      */
     public function __construct(
-        public readonly GraphQLFileSource | InlineSource | TwigFileSource $source,
+        public readonly GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         public readonly string $path,
         public readonly string $fqcn,
         public readonly NamedType & Type $parentType,

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -31,6 +31,7 @@ use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\PossibleTypesFinder;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
+use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineFragmentSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\RecursiveTypeFinder;
@@ -68,6 +69,11 @@ final class SelectionSetPlanner
      * @var array<string, array{FragmentDefinitionNodeWithSource, list<string>}> Fragment name to definition mapping
      */
     public private(set) array $fragmentDefinitions = [];
+
+    /**
+     * @var array<string, string> Fragment name to fully-qualified class name mapping
+     */
+    public private(set) array $fragmentFqcns = [];
     private PossibleTypesFinder $possibleTypesFinder;
 
     public function __construct(
@@ -90,7 +96,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     public function plan(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         Type $parent,
         string $outputDirectory,
@@ -133,7 +139,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     public function planSelectionSet(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         Type $type,
         PlanningContext $context,
@@ -211,7 +217,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function planNamedTypeSelectionSet(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         SelectionSetNode $selectionSet,
         NamedType & Type $type,
         PlanningContext $context,
@@ -307,7 +313,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processFieldSelection(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         FieldNode $selection,
         Type $parent,
         PlanningContext $context,
@@ -406,7 +412,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processNestedSelection(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         FieldNode $selection,
         string $fieldName,
         Type $fieldType,
@@ -479,7 +485,7 @@ final class SelectionSetPlanner
      * @throws LogicException
      */
     private function processInlineFragment(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         InlineFragmentNode $selection,
         Type $parent,
         PlanningContext $context,
@@ -609,7 +615,7 @@ final class SelectionSetPlanner
 
         // Always add the fragment wrapper for backward compatibility
         $fragmentObjectType = new FragmentObjectType(
-            $this->fullyQualified('Fragment', $selection->name->value),
+            $this->fragmentFqcns[$selection->name->value] ?? $this->fullyQualified('Fragment', $selection->name->value),
             $selection->name->value,
             $fragmentType,
         );
@@ -948,7 +954,7 @@ final class SelectionSetPlanner
      * @throws InvariantViolation
      */
     private function createDataClassPlan(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         NamedType & Type $parentType,
         SelectionSetResult $result,
         PlanningContext $context,
@@ -994,7 +1000,7 @@ final class SelectionSetPlanner
     }
 
     private function createInlineFragmentClassPlan(
-        GraphQLFileSource | InlineSource | TwigFileSource $source,
+        GraphQLFileSource | InlineFragmentSource | InlineSource | TwigFileSource $source,
         NamedType & Type $fragmentType,
         FieldCollection $fields,
         PayloadShape $payloadShape,
@@ -1105,6 +1111,11 @@ final class SelectionSetPlanner
     public function setFragmentType(string $name, NamedType & Type $type) : void
     {
         $this->fragmentTypes[$name] = $type;
+    }
+
+    public function setFragmentFqcn(string $name, string $fqcn) : void
+    {
+        $this->fragmentFqcns[$name] = $fqcn;
     }
 
     /**

--- a/src/Planner/Source/InlineFragmentSource.php
+++ b/src/Planner/Source/InlineFragmentSource.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Planner\Source;
+
+final readonly class InlineFragmentSource
+{
+    public function __construct(
+        public string $class,
+        public string $method,
+        public string $parameter,
+        public string $hash,
+    ) {}
+}

--- a/tests/InlineFragment/FeaturedUsersClient.php
+++ b/tests/InlineFragment/FeaturedUsersClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829\FeaturedUsersQuery;
+
+final readonly class FeaturedUsersClient
+{
+    private const string OPERATION = <<<'GRAPHQL'
+        query FeaturedUsers {
+            featuredUsers {
+                ...UserName
+            }
+        }
+        GRAPHQL;
+
+    public function __construct(
+        #[GeneratedGraphQLClient(self::OPERATION)]
+        private FeaturedUsersQuery $query,
+        private UserMapper $mapper,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function getDisplayNames() : array
+    {
+        return $this->mapper->mapMany(
+            array_map(fn($user) => $user->userName, $this->query->execute()->featuredUsers),
+        );
+    }
+}

--- a/tests/InlineFragment/Generated/Fragment/UserName56995d/UserName.php
+++ b/tests/InlineFragment/Generated/Fragment/UserName56995d/UserName.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Fragment\UserName56995d;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\UserMapper;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: UserMapper::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class UserName
+{
+    public string $firstName {
+        get => $this->firstName ??= $this->data['firstName'];
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $lastName {
+        get => $this->lastName ??= $this->data['lastName'];
+    }
+
+    /**
+     * @param array{
+     *     'firstName': string,
+     *     'id': string,
+     *     'lastName': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\FeaturedUsersClient;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829\Data\FeaturedUser;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: FeaturedUsersClient::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class Data
+{
+    /**
+     * @var list<FeaturedUser>
+     */
+    public array $featuredUsers {
+        get => $this->featuredUsers ??= array_map(fn($item) => new FeaturedUser($item), $this->data['featuredUsers']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'featuredUsers': list<array{
+     *         'firstName': string,
+     *         'id': string,
+     *         'lastName': string,
+     *     }>,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data/FeaturedUser.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data/FeaturedUser.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829\Data;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\FeaturedUsersClient;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Fragment\UserName56995d\UserName;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: FeaturedUsersClient::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class FeaturedUser
+{
+    public UserName $userName {
+        get => $this->userName ??= new UserName($this->data);
+    }
+
+    /**
+     * @param array{
+     *     'firstName': string,
+     *     'id': string,
+     *     'lastName': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Error.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/FeaturedUsersQuery.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/FeaturedUsersQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\FeaturedUsers5a9829;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\FeaturedUsersClient;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: FeaturedUsersClient::class,
+    restricted: true,
+)]
+final readonly class FeaturedUsersQuery {
+    public const string OPERATION_NAME = 'FeaturedUsers';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query FeaturedUsers {
+          featuredUsers {
+            ...UserName
+          }
+        }
+        
+        fragment UserName on User {
+          id
+          firstName
+          lastName
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe\Data\User;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\ListUsersClient;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: ListUsersClient::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class Data
+{
+    /**
+     * @var list<User>
+     */
+    public array $users {
+        get => $this->users ??= array_map(fn($item) => new User($item), $this->data['users']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'users': list<array{
+     *         'firstName': string,
+     *         'id': string,
+     *         'lastName': string,
+     *     }>,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data/User.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data/User.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe\Data;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Fragment\UserName56995d\UserName;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\ListUsersClient;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: ListUsersClient::class,
+    restricted: true,
+    restrictInstantiation: true,
+)]
+final class User
+{
+    public UserName $userName {
+        get => $this->userName ??= new UserName($this->data);
+    }
+
+    /**
+     * @param array{
+     *     'firstName': string,
+     *     'id': string,
+     *     'lastName': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Error.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/ListUsersQuery.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/ListUsersQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\ListUsersClient;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+#[Generated(
+    source: ListUsersClient::class,
+    restricted: true,
+)]
+final readonly class ListUsersQuery {
+    public const string OPERATION_NAME = 'ListUsers';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query ListUsers {
+          users {
+            ...UserName
+          }
+        }
+        
+        fragment UserName on User {
+          id
+          firstName
+          lastName
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/InlineFragment/InlineFragmentTest.php
+++ b/tests/InlineFragment/InlineFragmentTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLRequestMatcher;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+
+final class InlineFragmentTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->enableGeneratedAttribute()
+            ->withInlineProcessingDirectory(__DIR__);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testMapper() : void
+    {
+        $mapper = new UserMapper();
+
+        $listClient = new ListUsersClient(
+            new Generated\Query\ListUsers9908fe\ListUsersQuery($this->getClient(
+                [
+                    'data' => [
+                        'users' => [
+                            [
+                                'id' => '1',
+                                'firstName' => 'Ruud',
+                                'lastName' => 'Kamphuis',
+                            ],
+                            [
+                                'id' => '2',
+                                'firstName' => 'Jane',
+                                'lastName' => 'Doe',
+                            ],
+                        ],
+                    ],
+                ],
+                new GraphQLRequestMatcher(operationName: 'ListUsers'),
+            )),
+            $mapper,
+        );
+
+        $featuredClient = new FeaturedUsersClient(
+            new Generated\Query\FeaturedUsers5a9829\FeaturedUsersQuery($this->getClient(
+                [
+                    'data' => [
+                        'featuredUsers' => [
+                            [
+                                'id' => '3',
+                                'firstName' => 'Featured',
+                                'lastName' => 'Person',
+                            ],
+                        ],
+                    ],
+                ],
+                new GraphQLRequestMatcher(operationName: 'FeaturedUsers'),
+            )),
+            $mapper,
+        );
+
+        self::assertSame(['Ruud Kamphuis', 'Jane Doe'], $listClient->getDisplayNames());
+        self::assertSame(['Featured Person'], $featuredClient->getDisplayNames());
+    }
+}

--- a/tests/InlineFragment/ListUsersClient.php
+++ b/tests/InlineFragment/ListUsersClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLClient;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Query\ListUsers9908fe\ListUsersQuery;
+
+final readonly class ListUsersClient
+{
+    private const string OPERATION = <<<'GRAPHQL'
+        query ListUsers {
+            users {
+                ...UserName
+            }
+        }
+        GRAPHQL;
+
+    public function __construct(
+        #[GeneratedGraphQLClient(self::OPERATION)]
+        private ListUsersQuery $query,
+        private UserMapper $mapper,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function getDisplayNames() : array
+    {
+        return $this->mapper->mapMany(
+            array_map(fn($user) => $user->userName, $this->query->execute()->users),
+        );
+    }
+}

--- a/tests/InlineFragment/Schema.graphql
+++ b/tests/InlineFragment/Schema.graphql
@@ -1,0 +1,11 @@
+type Query {
+    users: [User!]!
+    featuredUsers: [User!]!
+}
+
+type User {
+    id: ID!
+    firstName: String!
+    lastName: String!
+    email: String!
+}

--- a/tests/InlineFragment/UserMapper.php
+++ b/tests/InlineFragment/UserMapper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragment;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLFragment;
+use Ruudk\GraphQLCodeGenerator\InlineFragment\Generated\Fragment\UserName56995d\UserName;
+
+final readonly class UserMapper
+{
+    private const string FRAGMENT = <<<'GRAPHQL'
+        fragment UserName on User {
+            id
+            firstName
+            lastName
+        }
+        GRAPHQL;
+
+    /**
+     * @param list<UserName> $users
+     * @return list<string>
+     */
+    public function mapMany(
+        #[GeneratedGraphQLFragment(self::FRAGMENT)]
+        array $users,
+    ) : array {
+        return array_map(
+            fn(UserName $u) => $u->firstName . ' ' . $u->lastName,
+            $users,
+        );
+    }
+}


### PR DESCRIPTION
A service that operates on a slice of GraphQL data — e.g. a UserMapper that needs `id, firstName, lastName` from any User — previously had no way to publish its own data contract. Callers had to know which fields the service read internally, and consumers passing fragment-shaped data across the service boundary lost type safety.

This attribute lets a service tag a method parameter with the fragment it consumes. The generator emits the fragment class at `Generated/Fragment/{Name}{hash}/{Name}.php` — hashed by declaration site, mirroring `#[GeneratedGraphQLClient]` — and stamps it with `#[Generated(source: …, restricted: true, restrictInstantiation: true)]` so PHPStan limits use to the declaring service. Any query (`.graphql`, Twig, or another inline `#[GeneratedGraphQLClient]`) can spread the fragment by name; the generated Data classes import the same hashed fragment class. Names remain globally unique across sources, with the existing duplicate-fragment check extended to PHP attributes.
