### PR TITLE
Inline possible types at fragment check sites

### DIFF
--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
@@ -14,11 +14,6 @@ namespace Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Search\Data\Search
  */
 final class AsIssue
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Issue'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/phpstan.php
+++ b/phpstan.php
@@ -54,7 +54,6 @@ return [
         'ignoreErrors' => [
             [
                 'identifiers' => [
-                    'shipmonk.deadConstant',
                     'shipmonk.deadMethod',
                 ],
                 'paths' => [
@@ -68,14 +67,6 @@ return [
                 'paths' => [
                     __DIR__ . '/tests/PHPStan/Fixtures/*',
                     __DIR__ . '/tests/StaleImportRemoval/ControllerWithStaleImport.php',
-                ],
-            ],
-            [
-                'identifiers' => [
-                    'shipmonk.deadConstant',
-                ],
-                'paths' => [
-                    __DIR__ . '/examples/Generated/*',
                 ],
             ],
             [

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -23,6 +23,7 @@ use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
 use Symfony\Component\TypeInfo\Type\ArrayShapeType;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
 
 final class DataClassGenerator extends AbstractGenerator
 {
@@ -38,7 +39,7 @@ final class DataClassGenerator extends AbstractGenerator
      * single source of truth (`ObjectTypeInitializer` + `ClassHookUsageRegistry`)
      * decides whether to forward `$this->hooks` into the child constructor.
      *
-     * @throws \Webmozart\Assert\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function initializeFragmentObject(FragmentObjectType $type, CodeGenerator $generator) : string
     {
@@ -55,7 +56,7 @@ final class DataClassGenerator extends AbstractGenerator
      * promoted to `?->` so the chain's static type stays accurate.
      *
      * @param array<string, DataClassPlan> $plansByFqcn
-     * @throws \Webmozart\Assert\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function buildHookInputAccessor(string $path, SymfonyType $fields, array $plansByFqcn) : string
     {
@@ -108,7 +109,24 @@ final class DataClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @throws \Webmozart\Assert\InvalidArgumentException
+     * @param array<string, DataClassPlan> $plansByFqcn
+     * @throws InvalidArgumentException
+     */
+    private function dumpPossibleTypesList(array $plansByFqcn, string $fqcn) : string
+    {
+        Assert::keyExists($plansByFqcn, $fqcn);
+
+        return implode(
+            ', ',
+            array_map(
+                fn(string $type) => var_export($type, true),
+                $plansByFqcn[$fqcn]->possibleTypes,
+            ),
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
      */
     private function unwrapShape(SymfonyType $type) : ArrayShapeType
     {
@@ -135,6 +153,7 @@ final class DataClassGenerator extends AbstractGenerator
         $isFragment = $plan->isFragment;
         $definitionNode = $plan->definitionNode;
         $nodesType = $plan->nodesType;
+
         /**
          * @var array<string, list<string>>
          */
@@ -149,7 +168,7 @@ final class DataClassGenerator extends AbstractGenerator
         }
 
         $parts = explode('\\', $fqcn);
-        $className = array_pop($parts);
+        array_pop($parts);
         $namespace = implode('\\', $parts);
 
         // For inline fragments with a single possible type, use literal type for __typename
@@ -165,7 +184,7 @@ final class DataClassGenerator extends AbstractGenerator
 
         $generator = new CodeGenerator($namespace);
 
-        return $generator->dumpFile(function () use ($plan, $definitionNode, $parentType, $nodesType, $fqcn, $payloadShape, $isData, $fields, $possibleTypes, $generator, $inlineFragmentRequiredFields, $plansByFqcn) {
+        return $generator->dumpFile(function () use ($plan, $definitionNode, $parentType, $nodesType, $fqcn, $payloadShape, $isData, $fields, $generator, $inlineFragmentRequiredFields, $plansByFqcn) {
             yield $this->dumpHeader();
             yield '';
 
@@ -207,18 +226,7 @@ final class DataClassGenerator extends AbstractGenerator
             $requiredFieldsMap = $inlineFragmentRequiredFields;
 
             yield $generator->indent(
-                function () use ($plan, $parentType, $nodesType, $possibleTypes, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap, $plansByFqcn) {
-                    if ($possibleTypes !== []) {
-                        yield from $generator->docComment('@var list<string>');
-                        yield sprintf(
-                            'public const array POSSIBLE_TYPES = [%s];',
-                            $generator->join(
-                                ', ',
-                                array_map(fn(string $type) => var_export($type, true), $possibleTypes),
-                            ),
-                        );
-                    }
-
+                function () use ($plan, $parentType, $nodesType, $fields, $isData, $payloadShape, $generator, $requiredFieldsMap, $plansByFqcn) {
                     // Get optional flags and actual types from payloadShape
                     $optionalFields = [];
                     $payloadFieldTypes = [];
@@ -322,7 +330,7 @@ final class DataClassGenerator extends AbstractGenerator
                                 $this->dumpPHPType($propertyType, $generator->import(...)),
                                 $fieldName,
                             );
-                            yield $generator->indent(function () use ($parentType, $nakedFieldType, $fieldType, $generator, $fieldName, $requiredFieldsMap, $optional, $payloadFieldTypes, $propertyType) {
+                            yield $generator->indent(function () use ($parentType, $nakedFieldType, $fieldType, $generator, $fieldName, $requiredFieldsMap, $optional, $payloadFieldTypes, $propertyType, $plansByFqcn) {
                                 if ($nakedFieldType instanceof FragmentObjectType) {
                                     // For interface/union parent types, we need special handling
                                     if ( ! $parentType instanceof ObjectType) {
@@ -338,9 +346,9 @@ final class DataClassGenerator extends AbstractGenerator
                                         // For fragments on interface/union types themselves
                                         if ($nakedFieldType->fragmentType instanceof InterfaceType || $nakedFieldType->fragmentType instanceof UnionType) {
                                             yield sprintf(
-                                                'get => $this->%s ??= in_array($this->data[\'__typename\'], %s::POSSIBLE_TYPES, true) ? %s : null;',
+                                                'get => $this->%s ??= in_array($this->data[\'__typename\'], [%s], true) ? %s : null;',
                                                 $fieldName,
-                                                $generator->import($nakedFieldType->getClassName()),
+                                                $this->dumpPossibleTypesList($plansByFqcn, $nakedFieldType->getClassName()),
                                                 $construct,
                                             );
 
@@ -504,7 +512,7 @@ final class DataClassGenerator extends AbstractGenerator
                                     'public bool $is%s {',
                                     $nakedFieldType->fragmentName,
                                 );
-                                yield $generator->indent(function () use ($nakedFieldType, $generator) {
+                                yield $generator->indent(function () use ($nakedFieldType, $plansByFqcn) {
                                     if ($nakedFieldType->fragmentType instanceof ObjectType) {
                                         yield sprintf(
                                             'get => $this->is%s ??= $this->data[\'__typename\'] === %s;',
@@ -516,9 +524,9 @@ final class DataClassGenerator extends AbstractGenerator
                                     }
 
                                     yield sprintf(
-                                        'get => $this->is%s ??= in_array($this->data[\'__typename\'], %s::POSSIBLE_TYPES, true);',
+                                        'get => $this->is%s ??= in_array($this->data[\'__typename\'], [%s], true);',
                                         $nakedFieldType->fragmentName,
-                                        $generator->import($nakedFieldType->getClassName()),
+                                        $this->dumpPossibleTypesList($plansByFqcn, $nakedFieldType->getClassName()),
                                     );
                                 });
                                 yield '}';

--- a/tests/Fragments/Generated/Fragment/ViewerName.php
+++ b/tests/Fragments/Generated/Fragment/ViewerName.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\Fragments\Generated\Fragment;
 
 final class ViewerName
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application', 'User'];
-
     public string $name {
         get => $this->name ??= $this->data['name'];
     }

--- a/tests/Fragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Viewer.php
@@ -12,11 +12,6 @@ use Ruudk\GraphQLCodeGenerator\Fragments\Generated\Fragment\ViewerName;
 
 final class Viewer
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application', 'User'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }
@@ -72,14 +67,14 @@ final class Viewer
     }
 
     public ?ViewerName $viewerName {
-        get => $this->viewerName ??= in_array($this->data['__typename'], ViewerName::POSSIBLE_TYPES, true) ? new ViewerName($this->data) : null;
+        get => $this->viewerName ??= in_array($this->data['__typename'], ['Application', 'User'], true) ? new ViewerName($this->data) : null;
     }
 
     /**
      * @phpstan-assert-if-true !null $this->viewerName
      */
     public bool $isViewerName {
-        get => $this->isViewerName ??= in_array($this->data['__typename'], ViewerName::POSSIBLE_TYPES, true);
+        get => $this->isViewerName ??= in_array($this->data['__typename'], ['Application', 'User'], true);
     }
 
     /**

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
@@ -11,11 +11,6 @@ use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\User;
 
 final class AsVariantA
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['VariantA'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Da
 
 final class AsVariantB
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['VariantB'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Viewer.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Viewer.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\IncludeAndSkipDirective\Generated\Query\Tes
 
 final class Viewer
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['User'];
-
     public string $name {
         get => $this->name ??= $this->data['name'];
     }

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
@@ -11,11 +11,6 @@ use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\Viewer\
 
 final class Viewer
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application', 'User'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\V
 
 final class AsApplication
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\V
 
 final class AsUser
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['User'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer.php
@@ -11,11 +11,6 @@ use Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test\Data\Viewer\AsU
 
 final class Viewer
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application', 'User'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -8,11 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test\Data\View
 
 final class AsUser
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['User'];
-
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
@@ -15,11 +15,6 @@ use Ruudk\GraphQLCodeGenerator\Attribute\Generated;
 )]
 final class Viewer
 {
-    /**
-     * @var list<string>
-     */
-    public const array POSSIBLE_TYPES = ['Application', 'User'];
-
     public string $name {
         get => $this->name ??= $this->data['name'];
     }


### PR DESCRIPTION
The `POSSIBLE_TYPES` constant was emitted on every data class but only ever read by other generated classes as a backdoor to the target's type list — never by the owning class itself. That makes it effectively a private API leaked through `public const`. On concrete-type classes it was also dead, since the generator inlines `__typename === 'X'` for single-type checks.

Inline the array literal at the two consumer sites (interface/union fragment getter and `is<Fragment>` boolean) by looking up the target plan's `possibleTypes` via `$plansByFqcn`, and stop emitting the constant entirely. The dead-constant PHPStan ignores for `tests/*/Generated/*` and `examples/Generated/*` are no longer needed.
