### PR TITLE
Split enableDumpOrThrows into method and property toggles

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -38,7 +38,8 @@ final readonly class Config
         public string $namespace,
         public string $client,
         public ?string $queriesDir = null,
-        public bool $dumpOrThrows = false,
+        public bool $dumpOrThrowMethods = false,
+        public bool $dumpOrThrowProperties = false,
         public bool $dumpDefinition = false,
         public bool $useNodeNameForEdgeNodes = false,
         public array $scalars = [],
@@ -79,10 +80,17 @@ final readonly class Config
         );
     }
 
-    public function enableDumpOrThrows() : self
+    public function enableDumpOrThrowMethods() : self
     {
         return clone ($this, [
-            'dumpOrThrows' => true,
+            'dumpOrThrowMethods' => true,
+        ]);
+    }
+
+    public function enableDumpOrThrowProperties() : self
+    {
+        return clone ($this, [
+            'dumpOrThrowProperties' => true,
         ]);
     }
 

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -532,7 +532,7 @@ final class DataClassGenerator extends AbstractGenerator
                                 yield '}';
                             }
 
-                            if ($this->config->dumpOrThrows && $propertyType instanceof SymfonyType\NullableType) {
+                            if ($this->config->dumpOrThrowProperties && $propertyType instanceof SymfonyType\NullableType) {
                                 $unwrappedType = $propertyType->getWrappedType();
 
                                 yield '';

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -204,7 +204,7 @@ final class OperationClassGenerator extends AbstractGenerator
                     });
                     yield '}';
 
-                    if ($this->config->dumpOrThrows) {
+                    if ($this->config->dumpOrThrowMethods) {
                         yield '';
                         yield from $generator->docComment(function () use ($plan, $failedException, $generator) {
                             foreach ($plan->variables as $name => $phpType) {

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -548,8 +548,7 @@ final class Planner
             }
         }
 
-        // Plan NodeNotFoundException only if dumpOrThrows is enabled
-        if ($this->config->dumpOrThrows) {
+        if ($this->config->dumpOrThrowProperties) {
             $queryType = $this->schema->getQueryType();
             Assert::notNull($queryType);
             $result->addClass(new NodeNotFoundExceptionPlan(
@@ -926,10 +925,9 @@ final class Planner
             $this->fullyQualified($operationType, $operationNamespaceName),
         );
 
-        // Create the exception class plan only if dumpOrThrows is enabled
         $exceptionClassPlan = null;
 
-        if ($this->config->dumpOrThrows) {
+        if ($this->config->dumpOrThrowMethods) {
             $exceptionClassPlan = new ExceptionClassPlan(
                 $operationDir . '/' . $operationName . $operationType . 'FailedException.php',
                 $this->fullyQualified($operationType, $operationNamespaceName),

--- a/tests/DumpOrThrows/DumpOrThrowsTest.php
+++ b/tests/DumpOrThrows/DumpOrThrowsTest.php
@@ -14,7 +14,9 @@ final class DumpOrThrowsTest extends GraphQLTestCase
     #[Override]
     public function getConfig() : Config
     {
-        return parent::getConfig()->enableDumpOrThrows();
+        return parent::getConfig()
+            ->enableDumpOrThrowMethods()
+            ->enableDumpOrThrowProperties();
     }
 
     public function testGenerate() : void

--- a/tests/IncludeAndSkipDirective/IncludeAndSkipDirectiveTest.php
+++ b/tests/IncludeAndSkipDirective/IncludeAndSkipDirectiveTest.php
@@ -15,7 +15,8 @@ final class IncludeAndSkipDirectiveTest extends GraphQLTestCase
     public function getConfig() : Config
     {
         return parent::getConfig()
-            ->enableDumpOrThrows();
+            ->enableDumpOrThrowMethods()
+            ->enableDumpOrThrowProperties();
     }
 
     public function testGenerate() : void

--- a/tests/InlineProcessing/InlineProcessingTest.php
+++ b/tests/InlineProcessing/InlineProcessingTest.php
@@ -16,7 +16,8 @@ final class InlineProcessingTest extends GraphQLTestCase
     {
         return parent::getConfig()
             ->enableGeneratedAttribute()
-            ->enableDumpOrThrows()
+            ->enableDumpOrThrowMethods()
+            ->enableDumpOrThrowProperties()
             ->withInlineProcessingDirectory(__DIR__);
     }
 

--- a/tests/Twig/TwigTest.php
+++ b/tests/Twig/TwigTest.php
@@ -18,7 +18,8 @@ final class TwigTest extends GraphQLTestCase
     {
         return parent::getConfig()
             ->enableGeneratedAttribute()
-            ->enableDumpOrThrows()
+            ->enableDumpOrThrowMethods()
+            ->enableDumpOrThrowProperties()
             ->enableDumpEnumIsMethods()
             ->withInlineProcessingDirectory(__DIR__)
             ->withTwigProcessingDirectory(__DIR__ . '/templates');


### PR DESCRIPTION
The single flag conflated two independent generation features: the operation-level `executeOrThrow()` method (with its `FailedException`) and the data-class `$fieldOrThrow` getters (with `NodeNotFoundException`). Consumers that wanted only one were forced to opt into both, so split into `enableDumpOrThrowMethods()` and `enableDumpOrThrowProperties()`.

Breaking change: `enableDumpOrThrows()` is removed; call sites must choose one or both of the new methods.
