### PR TITLE
Add @throwWhenNull directive for non-null property generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ enum SearchType: string
 - **Lazy-loading** for nested objects (only instantiated when accessed)
 - **Connection pattern awareness** (edges, nodes, pageInfo) for Relay-style APIs
 - **Custom `@indexBy` directive** for O(1) lookups instead of O(n) searching
+- **Custom `@throwWhenNull` directive** - drop nullability per-field and throw a typed exception when the server returns null
 - **Custom `@hook` directive** - enrich responses with local data resolved lazily at access time
 - **Fragment dependency injection** - automatically includes required fragments
 - **Automatic query optimization** - merges fragments, simplifies inline fragments
@@ -701,6 +702,87 @@ final class Data
     }
 }
 ```
+
+### 💥 Throw on Null with `@throwWhenNull` Directive
+
+Some nullable fields are nullable only for legacy or convenience reasons — at the point you read
+them, you know they must be set, and you'd rather get a typed exception than a `TypeError` deep in
+your code.
+
+Enable the directive once with `enableThrowWhenNullDirective()`, then tag a selection with
+`@throwWhenNull` and the generated property loses its nullability and throws
+`NodeNotFoundException` if the server returns `null` for that field. Works on scalars and objects.
+The directive is local to your query — it is stripped from the operation sent to the server and
+does not need to be defined in your schema. It is independent from `enableDumpOrThrowProperties()`:
+the exception class is generated whenever any field uses the directive.
+
+<!-- source: tests/ThrowWhenNullDirective/Test.graphql -->
+```graphql
+query Test {
+    viewer @throwWhenNull {
+        login
+        description @throwWhenNull
+        project @throwWhenNull {
+            id
+            name
+        }
+    }
+}
+```
+
+**Generated code:**
+
+<!-- source: tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer.php -->
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\NodeNotFoundException;
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $description {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : throw NodeNotFoundException::create('Viewer', 'description');
+    }
+
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    public Project $project {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->project ??= $this->data['project'] !== null ? new Project($this->data['project']) : throw NodeNotFoundException::create('Viewer', 'project');
+    }
+
+    /**
+     * @param array{
+     *     'description': null|string,
+     *     'login': string,
+     *     'project': null|array{
+     *         'id': string,
+     *         'name': string,
+     *     },
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}
+```
+
+Applying the directive to a non-nullable schema field raises a planning error — the directive
+exists to express intent that the server may return null but the consumer requires a value.
 
 ### 🪝 Local Resolution with `@hook` Directive
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -54,6 +54,7 @@ final readonly class Config
         public bool $addSymfonyExcludeAttribute = false,
         public bool $addGeneratedAttribute = false,
         public bool $indexByDirective = false,
+        public bool $throwWhenNullDirective = false,
         public bool $addUnknownCaseToEnums = false,
         public bool $dumpEnumIsMethods = false,
         public ?object $introspectionClient = null,
@@ -147,6 +148,13 @@ final readonly class Config
     {
         return clone ($this, [
             'indexByDirective' => true,
+        ]);
+    }
+
+    public function enableThrowWhenNullDirective() : self
+    {
+        return clone ($this, [
+            'throwWhenNullDirective' => true,
         ]);
     }
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -12,7 +12,9 @@ use GraphQL\Utils\SchemaPrinter;
 use Ruudk\GraphQLCodeGenerator\Config\ConfigException;
 use Ruudk\GraphQLCodeGenerator\Config\ConfigLoader;
 use Ruudk\GraphQLCodeGenerator\Executor\PlanExecutor;
+use Ruudk\GraphQLCodeGenerator\GraphQL\HookDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\GraphQL\IndexByDirectiveSchemaExtender;
+use Ruudk\GraphQLCodeGenerator\GraphQL\ThrowWhenNullDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\Planner;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
@@ -115,6 +117,14 @@ final class GenerateCommand
 
                     if ($configItem->indexByDirective) {
                         $schema = IndexByDirectiveSchemaExtender::extend($schema);
+                    }
+
+                    if ($configItem->hooks !== []) {
+                        $schema = HookDirectiveSchemaExtender::extend($schema);
+                    }
+
+                    if ($configItem->throwWhenNullDirective) {
+                        $schema = ThrowWhenNullDirectiveSchemaExtender::extend($schema);
                     }
 
                     $this->filesystem->dumpFile(

--- a/src/DirectiveProcessor.php
+++ b/src/DirectiveProcessor.php
@@ -46,6 +46,20 @@ final class DirectiveProcessor
     }
 
     /**
+     * @param NodeList<DirectiveNode> $directives
+     */
+    public function hasThrowWhenNullDirective(NodeList $directives) : bool
+    {
+        foreach ($directives as $directive) {
+            if ($directive->name->value === 'throwWhenNull') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Extract the @hook directive's `name` and `input` arguments.
      *
      * @param NodeList<DirectiveNode> $directives

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -18,6 +18,7 @@ use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
 use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
 use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
+use Ruudk\GraphQLCodeGenerator\Type\ThrowWhenNullPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\TypeDumper;
 use Ruudk\GraphQLCodeGenerator\TypeInitializer\DelegatingTypeInitializer;
 use Symfony\Component\TypeInfo\Type\ArrayShapeType;
@@ -294,6 +295,50 @@ final class DataClassGenerator extends AbstractGenerator
                                             $args,
                                         ),
                                         ';',
+                                    );
+                                });
+                                yield '}';
+
+                                continue;
+                            }
+
+                            if ($fieldType instanceof ThrowWhenNullPropertyType) {
+                                $wrappedType = $fieldType->getWrappedType();
+
+                                yield from $generator->docComment(function () use ($wrappedType, $generator) {
+                                    if ($this->getNakedType($wrappedType) instanceof SymfonyType\CollectionType) {
+                                        yield sprintf(
+                                            '@var %s',
+                                            TypeDumper::dump($wrappedType, $generator->import(...)),
+                                        );
+                                    }
+                                });
+                                yield sprintf(
+                                    'public %s $%s {',
+                                    $this->dumpPHPType($wrappedType, $generator->import(...)),
+                                    $fieldName,
+                                );
+                                yield $generator->indent(function () use ($wrappedType, $fieldName, $generator, $parentType) {
+                                    yield from $generator->docComment(function () use ($generator) {
+                                        yield sprintf('@throws %s', $generator->import($this->fullyQualified('NodeNotFoundException')));
+                                    });
+                                    yield from $generator->wrap(
+                                        sprintf(
+                                            'get => $this->%s ??= $this->data[%s] !== null ? ',
+                                            $fieldName,
+                                            var_export($fieldName, true),
+                                        ),
+                                        $this->typeInitializer->__invoke(
+                                            $wrappedType,
+                                            $generator,
+                                            sprintf('$this->data[%s]', var_export($fieldName, true)),
+                                        ),
+                                        sprintf(
+                                            ' : throw %s::create(%s, %s);',
+                                            $generator->import($this->fullyQualified('NodeNotFoundException')),
+                                            var_export($parentType->name(), true),
+                                            var_export($fieldName, true),
+                                        ),
                                     );
                                 });
                                 yield '}';

--- a/src/GraphQL/ThrowWhenNullDirectiveSchemaExtender.php
+++ b/src/GraphQL/ThrowWhenNullDirectiveSchemaExtender.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\SchemaExtender;
+use InvalidArgumentException;
+use JsonException;
+use Webmozart\Assert\Assert;
+
+final readonly class ThrowWhenNullDirectiveSchemaExtender
+{
+    /**
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     * @throws InvariantViolation
+     * @throws Exception
+     */
+    public static function extend(Schema $schema) : Schema
+    {
+        $existing = $schema->getDirective('throwWhenNull');
+
+        if ($existing !== null) {
+            Assert::eq($existing->locations, ['FIELD'], 'Expected @throwWhenNull to be on FIELD');
+            Assert::count($existing->args, 0, 'Expected @throwWhenNull to have 0 arguments');
+
+            return $schema;
+        }
+
+        return SchemaExtender::extend(
+            $schema,
+            Parser::parse(
+                <<<'GRAPHQL'
+                    directive @throwWhenNull on FIELD
+                    GRAPHQL,
+            ),
+        );
+    }
+}

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -84,11 +84,13 @@ use Ruudk\GraphQLCodeGenerator\Planner\Source\TwigFileSource;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLExtension;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLNodeFinder;
 use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
+use Ruudk\GraphQLCodeGenerator\Type\ThrowWhenNullPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\TypeHelper;
 use Ruudk\GraphQLCodeGenerator\Validator\IndexByValidator;
 use Ruudk\GraphQLCodeGenerator\Visitor\DefinedFragmentsVisitor;
 use Ruudk\GraphQLCodeGenerator\Visitor\HookFieldRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\IndexByRemover;
+use Ruudk\GraphQLCodeGenerator\Visitor\ThrowWhenNullRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\UsedFragmentsVisitor;
 use Stringable;
 use Symfony\Component\Filesystem\Filesystem;
@@ -164,7 +166,7 @@ final class Planner
         ];
 
         $this->schemaLoader = new SchemaLoader(new Filesystem());
-        $this->schema = $this->schemaLoader->load($config->schema, $config->indexByDirective, $config->hooks !== []);
+        $this->schema = $this->schemaLoader->load($config->schema, $config->indexByDirective, $config->hooks !== [], $config->throwWhenNullDirective);
         $this->optimizer = new Optimizer($this->schema);
         $this->possibleTypesFinder = new PossibleTypesFinder($this->schema);
 
@@ -548,14 +550,6 @@ final class Planner
             }
         }
 
-        if ($this->config->dumpOrThrowProperties) {
-            $queryType = $this->schema->getQueryType();
-            Assert::notNull($queryType);
-            $result->addClass(new NodeNotFoundExceptionPlan(
-                path: $this->config->outputDir . '/NodeNotFoundException.php',
-            ));
-        }
-
         // Plan fragments
         $ordered = FragmentOrderer::orderFragments($operations);
 
@@ -675,7 +669,30 @@ final class Planner
             $this->propagateUsedHooks($result);
         }
 
+        if ($this->config->dumpOrThrowProperties || $this->anyClassUsesThrowWhenNull($result)) {
+            $result->addClass(new NodeNotFoundExceptionPlan(
+                path: $this->config->outputDir . '/NodeNotFoundException.php',
+            ));
+        }
+
         return $result;
+    }
+
+    private function anyClassUsesThrowWhenNull(PlannerResult $result) : bool
+    {
+        foreach ($result->classes as $plan) {
+            if ( ! $plan instanceof DataClassPlan) {
+                continue;
+            }
+
+            foreach ($this->fieldTypesIn($plan->fields) as $fieldType) {
+                if ($fieldType instanceof ThrowWhenNullPropertyType) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -862,6 +879,10 @@ final class Planner
 
         if ($this->config->hooks !== []) {
             $document = new HookFieldRemover()->__invoke($document);
+        }
+
+        if ($this->config->throwWhenNullDirective) {
+            $document = new ThrowWhenNullRemover()->__invoke($document);
         }
 
         $operationDefinition = Printer::doPrint($document);

--- a/src/Planner/FieldCollection.php
+++ b/src/Planner/FieldCollection.php
@@ -23,6 +23,11 @@ final class FieldCollection
         return $this;
     }
 
+    public function get(string $name) : SymfonyType
+    {
+        return $this->fields[$name];
+    }
+
     public function merge(FieldCollection $other) : self
     {
         foreach ($other->fields as $name => $type) {

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -39,6 +39,7 @@ use Ruudk\GraphQLCodeGenerator\Type\FragmentObjectType;
 use Ruudk\GraphQLCodeGenerator\Type\HookPropertyType;
 use Ruudk\GraphQLCodeGenerator\Type\IndexByCollectionType;
 use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
+use Ruudk\GraphQLCodeGenerator\Type\ThrowWhenNullPropertyType;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
 use Symfony\Component\String\Inflector\EnglishInflector;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
@@ -361,6 +362,22 @@ final class SelectionSetPlanner
             ? $fieldType->getInnermostType()
             : $fieldType;
 
+        $throwWhenNull = $this->directiveProcessor->hasThrowWhenNullDirective($selection->directives);
+
+        if ($throwWhenNull) {
+            Assert::isInstanceOf($parent, NamedType::class);
+            Assert::isInstanceOf(
+                $fieldType,
+                NullableType::class,
+                sprintf(
+                    '@throwWhenNull on "%s.%s" requires a nullable field, got %s.',
+                    $parent->name(),
+                    $selection->name->value,
+                    $fieldType->toString(),
+                ),
+            );
+        }
+
         // Handle predefined object types
         if ($nakedFieldType instanceof ObjectType && isset($this->config->objectTypes[$nakedFieldType->name()])) {
             [$objectPayloadShape, $objectType] = $this->config->objectTypes[$nakedFieldType->name()];
@@ -373,7 +390,7 @@ final class SelectionSetPlanner
                 ? SymfonyType::nullable($objectPayloadShape)
                 : $objectPayloadShape;
 
-            $fields->add($fieldName, $finalType);
+            $fields->add($fieldName, $throwWhenNull ? new ThrowWhenNullPropertyType($objectType) : $finalType);
             $payloadShape->addRequired($fieldName, $finalPayloadShape);
 
             return;
@@ -394,12 +411,23 @@ final class SelectionSetPlanner
                 $payloadShape,
             );
 
+            if ($throwWhenNull) {
+                $stored = $fields->get($fieldName);
+                $unwrapped = $stored instanceof SymfonyType\NullableType ? $stored->getWrappedType() : $stored;
+                $fields->add($fieldName, new ThrowWhenNullPropertyType($unwrapped));
+            }
+
             return;
         }
 
         // Handle scalar fields
         $mappedType = $this->typeMapper->mapGraphQLTypeToPHPType($fieldType);
         $mappedPayloadType = $this->typeMapper->mapGraphQLTypeToPHPType($fieldType, builtInOnly: true);
+
+        if ($throwWhenNull) {
+            $unwrapped = $mappedType instanceof SymfonyType\NullableType ? $mappedType->getWrappedType() : $mappedType;
+            $mappedType = new ThrowWhenNullPropertyType($unwrapped);
+        }
 
         $fields->add($fieldName, $mappedType);
         $pathFields->addWithPrefix($context->path, $fieldName, $mappedType);

--- a/src/SchemaLoader.php
+++ b/src/SchemaLoader.php
@@ -28,7 +28,7 @@ final class SchemaLoader
      * @throws \Symfony\Component\Filesystem\Exception\IOException
      * @throws \Webmozart\Assert\InvalidArgumentException
      */
-    public function load(Schema | string $schema, bool $indexByDirective, bool $hookDirective) : Schema
+    public function load(Schema | string $schema, bool $indexByDirective, bool $hookDirective, bool $throwWhenNullDirective) : Schema
     {
         if (is_string($schema) && str_ends_with($schema, '.graphql')) {
             $this->schemaPath = $schema;
@@ -53,6 +53,10 @@ final class SchemaLoader
 
         if ($hookDirective) {
             $schema = GraphQL\HookDirectiveSchemaExtender::extend($schema);
+        }
+
+        if ($throwWhenNullDirective) {
+            $schema = GraphQL\ThrowWhenNullDirectiveSchemaExtender::extend($schema);
         }
 
         return $schema;

--- a/src/Type/ThrowWhenNullPropertyType.php
+++ b/src/Type/ThrowWhenNullPropertyType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Type;
+
+use Override;
+use Symfony\Component\TypeInfo\Type as SymfonyType;
+use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+
+/**
+ * Marker wrapper signalling that a generated property must throw a
+ * `NodeNotFoundException` when the underlying payload value is null. The
+ * wrapped type is the (already non-nullable) PHP type used for the property
+ * declaration.
+ *
+ * Set by `SelectionSetPlanner` when a field carries `@throwWhenNull`; consumed
+ * by `DataClassGenerator` to emit the throwing getter.
+ *
+ * @implements WrappingTypeInterface<SymfonyType>
+ */
+final class ThrowWhenNullPropertyType extends SymfonyType implements WrappingTypeInterface
+{
+    public function __construct(
+        private readonly SymfonyType $wrappedType,
+    ) {}
+
+    #[Override]
+    public function getWrappedType() : SymfonyType
+    {
+        return $this->wrappedType;
+    }
+
+    #[Override]
+    public function wrappedTypeIsSatisfiedBy(callable $specification) : bool
+    {
+        return $specification($this->wrappedType);
+    }
+
+    #[Override]
+    public function __toString() : string
+    {
+        return (string) $this->wrappedType;
+    }
+}

--- a/src/Visitor/ThrowWhenNullRemover.php
+++ b/src/Visitor/ThrowWhenNullRemover.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Visitor;
+
+use Exception;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorRemoveNode;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+final readonly class ThrowWhenNullRemover
+{
+    /**
+     * @template T of Node
+     * @param T $node
+     *
+     * @throws InvalidArgumentException
+     * @throws Exception
+     * @return T
+     */
+    public function __invoke(Node $node) : Node
+    {
+        $new = Visitor::visit($node, [
+            NodeKind::DIRECTIVE => function (Node $node) : ?VisitorRemoveNode {
+                Assert::isInstanceOf($node, DirectiveNode::class);
+
+                if ($node->name->value !== 'throwWhenNull') {
+                    return null;
+                }
+
+                return Visitor::removeNode();
+            },
+        ]);
+
+        Assert::isInstanceOf($new, Node::class);
+        Assert::isAOf($new, $node::class);
+
+        return $new;
+    }
+}

--- a/tests/ThrowWhenNullDirective/Generated/NodeNotFoundException.php
+++ b/tests/ThrowWhenNullDirective/Generated/NodeNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated;
+
+use Exception;
+
+// This file was automatically generated and should not be edited.
+
+final class NodeNotFoundException extends Exception
+{
+    public static function create(string $node, string $property) : self
+    {
+        return new self(sprintf('Field %s.%s is null', $node, $property));
+    }
+}

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\NodeNotFoundException;
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Viewer $viewer {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->viewer ??= $this->data['viewer'] !== null ? new Viewer($this->data['viewer']) : throw NodeNotFoundException::create('Query', 'viewer');
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'viewer': null|array{
+     *         'description': null|string,
+     *         'login': string,
+     *         'project': null|array{
+     *             'id': string,
+     *             'name': string,
+     *         },
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\NodeNotFoundException;
+use Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data\Viewer\Project;
+
+// This file was automatically generated and should not be edited.
+
+final class Viewer
+{
+    public string $description {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->description ??= $this->data['description'] !== null ? $this->data['description'] : throw NodeNotFoundException::create('Viewer', 'description');
+    }
+
+    public string $login {
+        get => $this->login ??= $this->data['login'];
+    }
+
+    public Project $project {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->project ??= $this->data['project'] !== null ? new Project($this->data['project']) : throw NodeNotFoundException::create('Viewer', 'project');
+    }
+
+    /**
+     * @param array{
+     *     'description': null|string,
+     *     'login': string,
+     *     'project': null|array{
+     *         'id': string,
+     *         'name': string,
+     *     },
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer/Project.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test\Data\Viewer;
+
+// This file was automatically generated and should not be edited.
+
+final class Project
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Error.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/TestQuery.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          viewer {
+            login
+            description
+            project {
+              id
+              name
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/ThrowWhenNullDirective/Schema.graphql
+++ b/tests/ThrowWhenNullDirective/Schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+    viewer: Viewer
+}
+
+type Viewer {
+    login: String!
+    description: String
+    project: Project
+}
+
+type Project {
+    id: ID!
+    name: String!
+}

--- a/tests/ThrowWhenNullDirective/Test.graphql
+++ b/tests/ThrowWhenNullDirective/Test.graphql
@@ -1,0 +1,10 @@
+query Test {
+    viewer @throwWhenNull {
+        login
+        description @throwWhenNull
+        project @throwWhenNull {
+            id
+            name
+        }
+    }
+}

--- a/tests/ThrowWhenNullDirective/ThrowWhenNullDirectiveTest.php
+++ b/tests/ThrowWhenNullDirective/ThrowWhenNullDirectiveTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ThrowWhenNullDirective;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+
+final class ThrowWhenNullDirectiveTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()->enableThrowWhenNullDirective();
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+}


### PR DESCRIPTION
Some nullable schema fields are nullable only for legacy or convenience reasons. At the read site the consumer often knows the value must be present and would prefer a typed exception over a TypeError deep in their own code.

Opt in with enableThrowWhenNullDirective() (mirroring the enableIndexByDirective() pattern), then tag a selection with @throwWhenNull. The generated property loses its outer nullability and throws NodeNotFoundException when the server returns null. The directive is local-only — registered via a schema extender and stripped from the operation before it leaves the client, so the server never sees it. Independent from enableDumpOrThrowProperties: the exception class is planned whenever any field carries the directive.

Applying the directive to a non-nullable field raises a planning error, since the directive only expresses intent that exists for nullable fields.

Also fixes --update-schema to inject the `@hook` and `@throwWhenNull` directives into the dumped schema file when their corresponding config options are enabled, matching the long-standing behavior for `@indexBy`.
