### PR TITLE
Propagate hook usage through @throwWhenNull fields

### DIFF
--- a/src/Planner.php
+++ b/src/Planner.php
@@ -724,6 +724,10 @@ final class Planner
             $childFqcnsByPlan[$plan->fqcn] = [];
 
             foreach ($this->fieldTypesIn($plan->fields) as $fieldType) {
+                if ($fieldType instanceof ThrowWhenNullPropertyType) {
+                    $fieldType = $fieldType->getWrappedType();
+                }
+
                 if ($fieldType instanceof HookPropertyType) {
                     $plan->usedHooks[$fieldType->hookName] = true;
 
@@ -792,6 +796,12 @@ final class Planner
     private function unwrapToObjectType(SymfonyType $type) : ?string
     {
         while (true) {
+            if ($type instanceof ThrowWhenNullPropertyType) {
+                $type = $type->getWrappedType();
+
+                continue;
+            }
+
             if ($type instanceof SymfonyType\NullableType) {
                 $type = $type->getWrappedType();
 

--- a/tests/HooksThroughSoleFragmentSpread/DiscountCode.php
+++ b/tests/HooksThroughSoleFragmentSpread/DiscountCode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread;
+
+final readonly class DiscountCode
+{
+    public function __construct(
+        public string $id,
+    ) {}
+}

--- a/tests/HooksThroughSoleFragmentSpread/FindDiscountCodeByIdHook.php
+++ b/tests/HooksThroughSoleFragmentSpread/FindDiscountCodeByIdHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread;
+
+use Ruudk\GraphQLCodeGenerator\Attribute\Hook;
+
+#[Hook(name: 'findDiscountCodeById')]
+final readonly class FindDiscountCodeByIdHook
+{
+    /**
+     * @param array<string, DiscountCode> $discountCodes
+     */
+    public function __construct(
+        private array $discountCodes = [],
+    ) {}
+
+    public function __invoke(string $id) : ?DiscountCode
+    {
+        return $this->discountCodes[$id] ?? null;
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Fragment;
+
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\FindDiscountCodeByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Fragment\ShowPaymentFlow\Order;
+
+// This file was automatically generated and should not be edited.
+
+final class ShowPaymentFlow
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public Order $order {
+        get => $this->order ??= new Order($this->data['order'], $this->hooks);
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'order': array{
+     *         'discountId': string,
+     *         'id': string,
+     *     },
+     * } $data
+     * @param array{
+     *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow/Order.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow/Order.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Fragment\ShowPaymentFlow;
+
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\DiscountCode;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\FindDiscountCodeByIdHook;
+
+// This file was automatically generated and should not be edited.
+
+final class Order
+{
+    public ?DiscountCode $discountCode {
+        get => $this->discountCode ??= $this->hooks['findDiscountCodeById']->__invoke($this->discountId);
+    }
+
+    public string $discountId {
+        get => $this->discountId ??= $this->data['discountId'];
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'discountId': string,
+     *     'id': string,
+     * } $data
+     * @param array{
+     *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/NodeNotFoundException.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/NodeNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated;
+
+use Exception;
+
+// This file was automatically generated and should not be edited.
+
+final class NodeNotFoundException extends Exception
+{
+    public static function create(string $node, string $property) : self
+    {
+        return new self(sprintf('Field %s.%s is null', $node, $property));
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\FindDiscountCodeByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\NodeNotFoundException;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test\Data\PaymentFlow;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public PaymentFlow $paymentFlow {
+        /**
+         * @throws NodeNotFoundException
+         */
+        get => $this->paymentFlow ??= $this->data['paymentFlow'] !== null ? new PaymentFlow($this->data['paymentFlow'], $this->hooks) : throw NodeNotFoundException::create('Query', 'paymentFlow');
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'paymentFlow': null|array{
+     *         'id': string,
+     *         'order': array{
+     *             'discountId': string,
+     *             'id': string,
+     *         },
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     * @param array{
+     *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+        private readonly array $hooks,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data/PaymentFlow.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data/PaymentFlow.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\FindDiscountCodeByIdHook;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Fragment\ShowPaymentFlow;
+
+// This file was automatically generated and should not be edited.
+
+final class PaymentFlow
+{
+    public ShowPaymentFlow $showPaymentFlow {
+        get => $this->showPaymentFlow ??= new ShowPaymentFlow($this->data, $this->hooks);
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'order': array{
+     *         'discountId': string,
+     *         'id': string,
+     *     },
+     * } $data
+     * @param array{
+     *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly array $hooks,
+    ) {}
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Error.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\FindDiscountCodeByIdHook;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Stringable;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test($paymentFlowId: ID!) {
+          paymentFlow(id: $paymentFlowId) {
+            ...ShowPaymentFlow
+          }
+        }
+        
+        fragment ShowPaymentFlow on PaymentFlow {
+          id
+          order {
+            id
+            discountId
+          }
+        }
+        
+        GRAPHQL;
+
+    /**
+     * @param array{
+     *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     * } $hooks
+     */
+    public function __construct(
+        private TestClient $client,
+        private array $hooks,
+    ) {}
+
+    public function execute(
+        Stringable|string $paymentFlowId,
+    ) : Data {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+                'paymentFlowId' => (string) $paymentFlowId,
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [], // @phpstan-ignore argument.type
+            $this->hooks,
+        );
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/HooksThroughSoleFragmentSpreadTest.php
+++ b/tests/HooksThroughSoleFragmentSpread/HooksThroughSoleFragmentSpreadTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread;
+
+use Override;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\HooksThroughSoleFragmentSpread\Generated\Query\Test\TestQuery;
+
+final class HooksThroughSoleFragmentSpreadTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return parent::getConfig()
+            ->enableThrowWhenNullDirective()
+            ->withHook(FindDiscountCodeByIdHook::class);
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testQuery() : void
+    {
+        $findDiscountCodeById = new FindDiscountCodeByIdHook([
+            'discount-1' => new DiscountCode('discount-1'),
+        ]);
+
+        $result = new TestQuery(
+            $this->getClient([
+                'data' => [
+                    'paymentFlow' => [
+                        'id' => 'flow-1',
+                        'order' => [
+                            'id' => 'order-1',
+                            'discountId' => 'discount-1',
+                        ],
+                    ],
+                ],
+            ]),
+            [
+                'findDiscountCodeById' => $findDiscountCodeById,
+            ],
+        )->execute('flow-1');
+
+        self::assertSame('flow-1', $result->paymentFlow->showPaymentFlow->id);
+        self::assertSame('order-1', $result->paymentFlow->showPaymentFlow->order->id);
+        self::assertNotNull($result->paymentFlow->showPaymentFlow->order->discountCode);
+        self::assertSame('discount-1', $result->paymentFlow->showPaymentFlow->order->discountCode->id);
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Schema.graphql
+++ b/tests/HooksThroughSoleFragmentSpread/Schema.graphql
@@ -1,0 +1,13 @@
+type Query {
+    paymentFlow(id: ID!): PaymentFlow
+}
+
+type PaymentFlow {
+    id: ID!
+    order: Order!
+}
+
+type Order {
+    id: ID!
+    discountId: ID!
+}

--- a/tests/HooksThroughSoleFragmentSpread/ShowPaymentFlow.graphql
+++ b/tests/HooksThroughSoleFragmentSpread/ShowPaymentFlow.graphql
@@ -1,0 +1,8 @@
+fragment ShowPaymentFlow on PaymentFlow {
+    id
+    order {
+        id
+        discountId
+        discountCode @hook(name: "findDiscountCodeById", input: ["discountId"])
+    }
+}

--- a/tests/HooksThroughSoleFragmentSpread/Test.graphql
+++ b/tests/HooksThroughSoleFragmentSpread/Test.graphql
@@ -1,0 +1,5 @@
+query Test($paymentFlowId: ID!) {
+    paymentFlow(id: $paymentFlowId) @throwWhenNull {
+        ...ShowPaymentFlow
+    }
+}


### PR DESCRIPTION
A field carrying `@throwWhenNull` has its accessor type wrapped in `ThrowWhenNullPropertyType`, but `propagateUsedHooks` only peeled `NullableType`/`CollectionType` when unwrapping to the nested object type. As a result the child link from the root `Data` plan to the nested type was never recorded, so `Data->usedHooks` stayed empty: the constructor `$hooks` parameter and the `Query` class's `$hooks` argument were both omitted while the getter still emitted `$this->hooks`, yielding a runtime `TypeError` when the field's subtree used a hook (commonly via a fragment spread).

Unwrap `ThrowWhenNullPropertyType` both in the `propagateUsedHooks` field loop (before the `HookPropertyType` check, so `@throwWhenNull` directly on a hook field also propagates) and in `unwrapToObjectType`.
