### PR TITLE
Tag execute methods with @api PHPDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ final readonly class SearchQuery {
         private GitHubClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/examples/Generated/Query/Search/SearchQuery.php
+++ b/examples/Generated/Query/Search/SearchQuery.php
@@ -36,6 +36,9 @@ final readonly class SearchQuery {
         private GitHubClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/examples/Generated/Query/Viewer/ViewerQuery.php
+++ b/examples/Generated/Query/Viewer/ViewerQuery.php
@@ -23,6 +23,9 @@ final readonly class ViewerQuery {
         private GitHubClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -123,6 +123,8 @@ final class OperationClassGenerator extends AbstractGenerator
 
                     yield '';
                     yield from $generator->docComment(function () use ($plan, $generator) {
+                        yield '@api';
+
                         foreach ($plan->variables as $name => $phpType) {
                             if ( ! $phpType instanceof SymfonyType\CollectionType) {
                                 continue;
@@ -207,6 +209,8 @@ final class OperationClassGenerator extends AbstractGenerator
                     if ($this->config->dumpOrThrowMethods) {
                         yield '';
                         yield from $generator->docComment(function () use ($plan, $failedException, $generator) {
+                            yield '@api';
+
                             foreach ($plan->variables as $name => $phpType) {
                                 if ( ! $phpType instanceof SymfonyType\CollectionType) {
                                     continue;

--- a/tests/ConnectionNames/Generated/Query/Test/TestQuery.php
+++ b/tests/ConnectionNames/Generated/Query/Test/TestQuery.php
@@ -42,6 +42,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/DumpDefinitions/Generated/Query/Test/TestQuery.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/TestQuery.php
@@ -27,6 +27,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/DumpOrThrows/Generated/Query/Test/TestQuery.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/TestQuery.php
@@ -27,6 +27,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(
@@ -43,6 +46,7 @@ final readonly class TestQuery {
     }
 
     /**
+     * @api
      * @throws TestQueryFailedException
      */
     public function executeOrThrow() : Data

--- a/tests/Enum/Generated/Query/Test/TestQuery.php
+++ b/tests/Enum/Generated/Query/Test/TestQuery.php
@@ -24,6 +24,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/EnumDumpIsMethods/Generated/Query/Test/TestQuery.php
+++ b/tests/EnumDumpIsMethods/Generated/Query/Test/TestQuery.php
@@ -24,6 +24,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/GetWorkflowForAdminQuery.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/GetWorkflowForAdminQuery.php
@@ -61,6 +61,9 @@ final readonly class GetWorkflowForAdminQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         int|string|float|bool $workflowId,
     ) : Data {

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/GetTransactionDetailsQuery.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/GetTransactionDetailsQuery.php
@@ -65,6 +65,9 @@ final readonly class GetTransactionDetailsQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/Fragments/Generated/Query/Test/TestQuery.php
+++ b/tests/Fragments/Generated/Query/Test/TestQuery.php
@@ -51,6 +51,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/Hooks/Generated/Query/Test/TestQuery.php
+++ b/tests/Hooks/Generated/Query/Test/TestQuery.php
@@ -37,6 +37,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
@@ -37,6 +37,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -39,6 +39,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         Stringable|string $paymentFlowId,
     ) : Data {

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
@@ -39,6 +39,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -49,6 +49,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
@@ -34,6 +34,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
@@ -41,6 +41,9 @@ final readonly class TestQuery {
         private array $hooks,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/TestQuery.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/TestQuery.php
@@ -32,6 +32,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         bool $includeAdmin,
         bool $skipAdmin,
@@ -52,6 +55,7 @@ final readonly class TestQuery {
     }
 
     /**
+     * @api
      * @throws TestQueryFailedException
      */
     public function executeOrThrow(

--- a/tests/IndexByDirective/Generated/Query/Test/TestQuery.php
+++ b/tests/IndexByDirective/Generated/Query/Test/TestQuery.php
@@ -36,6 +36,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/TestMultiFieldQuery.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/TestMultiFieldQuery.php
@@ -36,6 +36,9 @@ final readonly class TestMultiFieldQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/FeaturedUsersQuery.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/FeaturedUsersQuery.php
@@ -35,6 +35,9 @@ final readonly class FeaturedUsersQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/ListUsersQuery.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/ListUsersQuery.php
@@ -35,6 +35,9 @@ final readonly class ListUsersQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/InlineFragments/Generated/Query/Test/TestQuery.php
+++ b/tests/InlineFragments/Generated/Query/Test/TestQuery.php
@@ -35,6 +35,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/ViewerProjectsQuery.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/ViewerProjectsQuery.php
@@ -33,6 +33,9 @@ final readonly class ViewerProjectsQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(
@@ -49,6 +52,7 @@ final readonly class ViewerProjectsQuery {
     }
 
     /**
+     * @api
      * @throws ViewerProjectsQueryFailedException
      */
     public function executeOrThrow() : Data

--- a/tests/Input/Generated/Mutation/Test/TestMutation.php
+++ b/tests/Input/Generated/Mutation/Test/TestMutation.php
@@ -24,6 +24,9 @@ final readonly class TestMutation {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         Stringable|string $firstName,
         CreateUserInput $input,

--- a/tests/ListScalar/Generated/Query/Test/TestQuery.php
+++ b/tests/ListScalar/Generated/Query/Test/TestQuery.php
@@ -25,6 +25,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/Money/Generated/Query/ConvertMoney/ConvertMoneyQuery.php
+++ b/tests/Money/Generated/Query/ConvertMoney/ConvertMoneyQuery.php
@@ -38,6 +38,9 @@ final readonly class ConvertMoneyQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         Money $amount,
         Currency $targetCurrency,

--- a/tests/NoIndexBy/Generated/Query/Test/TestQuery.php
+++ b/tests/NoIndexBy/Generated/Query/Test/TestQuery.php
@@ -36,6 +36,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/NullableConnections/Generated/Query/Test/TestQuery.php
+++ b/tests/NullableConnections/Generated/Query/Test/TestQuery.php
@@ -29,6 +29,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/OneOfDirective/Generated/Query/Test/TestQuery.php
+++ b/tests/OneOfDirective/Generated/Query/Test/TestQuery.php
@@ -25,6 +25,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute(
         UserByInput $by,
     ) : Data {

--- a/tests/Optimization/Generated/Query/Test/TestQuery.php
+++ b/tests/Optimization/Generated/Query/Test/TestQuery.php
@@ -45,6 +45,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/Simple/Generated/Query/Test/TestQuery.php
+++ b/tests/Simple/Generated/Query/Test/TestQuery.php
@@ -27,6 +27,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/GetViewerQuery.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/GetViewerQuery.php
@@ -23,6 +23,9 @@ final readonly class GetViewerQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/SymfonyExclude/Generated/Query/Test/TestQuery.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/TestQuery.php
@@ -27,6 +27,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/TestQuery.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/TestQuery.php
@@ -28,6 +28,9 @@ final readonly class TestQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(

--- a/tests/Twig/Generated/Query/Projectsd4cba6/ProjectsQuery.php
+++ b/tests/Twig/Generated/Query/Projectsd4cba6/ProjectsQuery.php
@@ -47,6 +47,9 @@ final readonly class ProjectsQuery {
         private TestClient $client,
     ) {}
 
+    /**
+     * @api
+     */
     public function execute() : Data
     {
         $data = $this->client->graphql(
@@ -63,6 +66,7 @@ final readonly class ProjectsQuery {
     }
 
     /**
+     * @api
      * @throws ProjectsQueryFailedException
      */
     public function executeOrThrow() : Data


### PR DESCRIPTION
Public entry-point methods on generated operation classes are only ever called by application code, never within the generated code itself. Tools like shipmonk/dead-code-detector therefore flag `execute` and `executeOrThrow` as unused.

Always emit an `@api` tag on these method signatures so dead-code analysis treats them as intentional public API. For `execute` this also means a doc block is now always generated, where previously it was omitted unless there were collection-typed `@param` lines.
