### PR TITLE
Tag fire-and-forget mutation __typename as @api

### DIFF
--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -379,8 +379,8 @@ final class DataClassGenerator extends AbstractGenerator
                                 $propertyType = SymfonyType::nullable($propertyType);
                             }
 
-                            yield from $generator->docComment(function () use ($propertyType, $isMutationData, $generator) {
-                                if ($isMutationData) {
+                            yield from $generator->docComment(function () use ($plan, $fieldName, $propertyType, $isMutationData, $generator) {
+                                if ($isMutationData || ($fieldName === '__typename' && $plan->markTypenameAsApi)) {
                                     yield '@api';
                                 }
 

--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -42,5 +42,13 @@ final class DataClassPlan
         public readonly array $inlineFragmentRequiredFields,
         public readonly bool $isData,
         public readonly bool $isFragment,
+        /**
+         * True when this class is a first-level mutation field whose only
+         * selection is an explicitly queried `__typename`. Such a selection
+         * is the idiomatic way to fire a mutation without caring about the
+         * response, so the generated `__typename` property is tagged `@api`
+         * to keep dead-code analysis from flagging it.
+         */
+        public readonly bool $markTypenameAsApi = false,
     ) {}
 }

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -1036,9 +1036,39 @@ final class SelectionSetPlanner
             inlineFragmentRequiredFields: $this->inlineFragmentRequiredFields,
             isData: false,
             isFragment: false,
+            markTypenameAsApi: $this->isSoleTypenameOnFirstLevelMutationField($context, $selection),
         );
 
         $this->result->addClass($dataClass);
+    }
+
+    /**
+     * A first-level mutation field selecting nothing but `__typename` is the
+     * idiomatic "fire and forget" mutation: the caller only wants the side
+     * effect. The generated `__typename` property is then never read, so we
+     * tag it `@api` to stop dead-code analysis from flagging it. This must
+     * NOT trigger when other fields are selected alongside `__typename`, nor
+     * when `__typename` appears deeper than the first level.
+     */
+    private function isSoleTypenameOnFirstLevelMutationField(
+        PlanningContext $context,
+        FieldNode $selection,
+    ) : bool {
+        // Root path is the operation type ("mutation"); a first-level field
+        // is therefore exactly "mutation.<fieldName>" (one separator).
+        if ( ! str_starts_with($context->path, 'mutation.') || substr_count($context->path, '.') !== 1) {
+            return false;
+        }
+
+        $selections = $selection->selectionSet?->selections;
+
+        if ($selections === null || count($selections) !== 1) {
+            return false;
+        }
+
+        $only = $selections[0];
+
+        return $only instanceof FieldNode && $only->name->value === '__typename';
     }
 
     private function createInlineFragmentClassPlan(

--- a/tests/MutationTypename/Generated/Mutation/Test/Data.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test;
+
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\FireAndForget;
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested;
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\WithExtraFields;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    /**
+     * @api
+     */
+    public FireAndForget $fireAndForget {
+        get => $this->fireAndForget ??= new FireAndForget($this->data['fireAndForget']);
+    }
+
+    /**
+     * @api
+     */
+    public Nested $nested {
+        get => $this->nested ??= new Nested($this->data['nested']);
+    }
+
+    /**
+     * @api
+     */
+    public WithExtraFields $withExtraFields {
+        get => $this->withExtraFields ??= new WithExtraFields($this->data['withExtraFields']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'fireAndForget': array{
+     *         '__typename': string,
+     *     },
+     *     'nested': array{
+     *         'inner': array{
+     *             '__typename': string,
+     *         },
+     *     },
+     *     'withExtraFields': array{
+     *         '__typename': string,
+     *         'name': string,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/FireAndForget.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/FireAndForget.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class FireAndForget
+{
+    /**
+     * @api
+     */
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/Nested.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/Nested.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested\Inner;
+
+// This file was automatically generated and should not be edited.
+
+final class Nested
+{
+    public Inner $inner {
+        get => $this->inner ??= new Inner($this->data['inner']);
+    }
+
+    /**
+     * @param array{
+     *     'inner': array{
+     *         '__typename': string,
+     *     },
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/Nested/Inner.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/Nested/Inner.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested;
+
+// This file was automatically generated and should not be edited.
+
+final class Inner
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/WithExtraFields.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/WithExtraFields.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class WithExtraFields
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/Error.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/MutationTypename/Generated/Mutation/Test/TestMutation.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/TestMutation.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestMutation {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        mutation Test {
+          fireAndForget {
+            __typename
+          }
+          withExtraFields {
+            __typename
+            name
+          }
+          nested {
+            inner {
+              __typename
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/MutationTypename/MutationTypenameTest.php
+++ b/tests/MutationTypename/MutationTypenameTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\MutationTypename;
+
+use ReflectionClass;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\FireAndForget;
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested\Inner;
+use Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\WithExtraFields;
+
+final class MutationTypenameTest extends GraphQLTestCase
+{
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    /**
+     * `mutation { fireAndForget { __typename } }` is the idiomatic way to
+     * run a mutation without caring about the response, so the generated
+     * __typename property is tagged @api.
+     */
+    public function testSoleTypenameOnFirstLevelMutationFieldIsApi() : void
+    {
+        $docComment = new ReflectionClass(FireAndForget::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
+    }
+
+    /**
+     * When other fields are selected alongside __typename, the caller does
+     * care about the response, so it must NOT be tagged @api.
+     */
+    public function testTypenameWithSiblingFieldsIsNotApi() : void
+    {
+        $docComment = new ReflectionClass(WithExtraFields::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        // Either no doc block at all, or one without @api.
+        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+    }
+
+    /**
+     * A __typename selected deeper than the first mutation level is regular
+     * data the caller asked for; it must NOT be tagged @api.
+     */
+    public function testTypenameDeeperThanFirstLevelIsNotApi() : void
+    {
+        $docComment = new ReflectionClass(Inner::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+    }
+}

--- a/tests/MutationTypename/Schema.graphql
+++ b/tests/MutationTypename/Schema.graphql
@@ -1,0 +1,26 @@
+type Query {
+    ping: String!
+}
+
+type Mutation {
+    fireAndForget: FireResult!
+    withExtraFields: ExtraResult!
+    nested: NestedResult!
+}
+
+type FireResult {
+    id: ID!
+}
+
+type ExtraResult {
+    id: ID!
+    name: String!
+}
+
+type NestedResult {
+    inner: Inner!
+}
+
+type Inner {
+    id: ID!
+}

--- a/tests/MutationTypename/Test.graphql
+++ b/tests/MutationTypename/Test.graphql
@@ -1,0 +1,14 @@
+mutation Test {
+    fireAndForget {
+        __typename
+    }
+    withExtraFields {
+        __typename
+        name
+    }
+    nested {
+        inner {
+            __typename
+        }
+    }
+}


### PR DESCRIPTION
`mutation { someMutation { __typename } }` is the idiomatic way to run a mutation purely for its side effect, without caring about the response. The generated `__typename` property is then never read by application code, so tools like shipmonk/dead-code-detector flag it as unused.

Tag that property `@api`, but only when it is genuinely the fire-and-forget shape: a first-level mutation field (planning path `mutation.<field>`) whose sole selection is an explicitly queried `__typename`. Selecting sibling fields, or a `__typename` nested deeper, means the caller does care about the response, so those are left untagged.
