### PR TITLE
Tag generated is<Fragment> helpers with @api

### DIFF
--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
@@ -48,6 +48,7 @@ final class Node
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asIssue
      */
     public bool $isIssue {
@@ -81,6 +82,7 @@ final class Node
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->pullRequestInfo
      */
     public bool $isPullRequestInfo {

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -573,7 +573,10 @@ final class DataClassGenerator extends AbstractGenerator
 
                             if ($nakedFieldType instanceof FragmentObjectType && $fieldType instanceof SymfonyType\NullableType) {
                                 yield '';
-                                yield from $generator->docComment(sprintf('@phpstan-assert-if-true !null $this->%s', $fieldName));
+                                yield from $generator->docComment(function () use ($fieldName) {
+                                    yield '@api';
+                                    yield sprintf('@phpstan-assert-if-true !null $this->%s', $fieldName);
+                                });
                                 yield sprintf(
                                     'public bool $is%s {',
                                     $nakedFieldType->fragmentName,

--- a/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
@@ -34,6 +34,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asApplication
      */
     public bool $isApplication {
@@ -63,6 +64,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->userDetails
      */
     public bool $isUserDetails {

--- a/tests/Fragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Viewer.php
@@ -31,6 +31,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->applicationDetails
      */
     public bool $isApplicationDetails {
@@ -56,6 +57,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->userDetails
      */
     public bool $isUserDetails {
@@ -67,6 +69,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->viewerName
      */
     public bool $isViewerName {

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
@@ -35,6 +35,7 @@ final class Thing
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asVariantA
      */
     public bool $isVariantA {
@@ -60,6 +61,7 @@ final class Thing
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asVariantB
      */
     public bool $isVariantB {

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
@@ -30,6 +30,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asApplication
      */
     public bool $isApplication {
@@ -55,6 +56,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asUser
      */
     public bool $isUser {

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer.php
@@ -34,6 +34,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->appUrl
      */
     public bool $isAppUrl {
@@ -63,6 +64,7 @@ final class Viewer
     }
 
     /**
+     * @api
      * @phpstan-assert-if-true !null $this->asUser
      */
     public bool $isUser {


### PR DESCRIPTION
The boolean `is<Fragment>` properties on generated `Data` classes are pure convenience accessors over `$this->data['__typename']`. They are only ever called by application code, never within the generated code itself, so tools like shipmonk/dead-code-detector flag them as unused.

Emit an `@api` tag on these helpers (alongside the existing `@phpstan-assert-if-true`) so dead-code analysis treats them as intentional public API.
