### PR TITLE
Guard against unused fragments

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -213,7 +213,19 @@ final class GenerateCommand
                         ));
                     }
 
-                    if ($unusedHooks !== []) {
+                    foreach ($plan->unusedFragments as $fragmentName => $location) {
+                        $io->writeln(sprintf(
+                            '<error>Fragment "%s" defined in %s is never used (never spread)</error>',
+                            $fragmentName,
+                            $location,
+                        ));
+                    }
+
+                    if ($plan->unusedFragments !== []) {
+                        $io->error('Unused fragments found. Remove them or reference them via ...FragmentName.');
+                    }
+
+                    if ($unusedHooks !== [] || $plan->unusedFragments !== []) {
                         $exitCode = Command::FAILURE;
 
                         continue;
@@ -237,6 +249,18 @@ final class GenerateCommand
                 }
 
                 $io->writeln('✅');
+
+                if ($plan->unusedFragments !== []) {
+                    $lines = [];
+                    foreach ($plan->unusedFragments as $fragmentName => $location) {
+                        $lines[] = sprintf('"%s" defined in %s', $fragmentName, $location);
+                    }
+
+                    $io->warning(sprintf(
+                        "The following fragments are never used (never spread). Consider removing them:\n  - %s",
+                        implode("\n  - ", $lines),
+                    ));
+                }
             } catch (Throwable $error) {
                 $io->writeln('❌');
                 $io->error(sprintf('Generation failed: %s', $error->getMessage()));

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -664,6 +664,7 @@ final class Planner
         $result->setDiscoveredInputObjectTypes($this->inputObjectTypes);
 
         $result->setOperationsToInject($operationsToInject);
+        $result->setUnusedFragments($this->findUnusedFragments($operations, $ordered));
 
         if ($this->config->hooks !== []) {
             $this->propagateUsedHooks($result);
@@ -676,6 +677,95 @@ final class Planner
         }
 
         return $result;
+    }
+
+    /**
+     * Detects fragments defined in a `.graphql` file or a `.twig` template
+     * that are never reachable from an operation. Reachability roots are the
+     * fragment spreads inside operations plus inline `#[GeneratedGraphQLFragment]`
+     * contracts (those are intentionally standalone, service-owned data
+     * contracts, so anything they spread counts as used). Inline fragment
+     * contracts themselves are out of scope: only file-defined fragments are
+     * reported, since those are the ones a developer can simply delete.
+     *
+     * @param array<string, list<DocumentNodeWithSource>> $operations
+     * @param list<FragmentDefinitionNodeWithSource> $ordered
+     * @throws Exception
+     * @return array<string, string> fragment name => relative source path
+     */
+    private function findUnusedFragments(array $operations, array $ordered) : array
+    {
+        /**
+         * @var array<string, list<string>> $fragmentSpreads
+         */
+        $fragmentSpreads = [];
+
+        /**
+         * @var array<string, string> $checkable
+         */
+        $checkable = [];
+
+        /**
+         * @var list<string> $queue
+         */
+        $queue = [];
+
+        foreach ($ordered as $fragment) {
+            $name = $fragment->name->value;
+            $fragmentSpreads[$name] = UsedFragmentsVisitor::getUsedFragments($fragment);
+
+            $source = $fragment->source;
+
+            if ($source instanceof GraphQLFileSource || $source instanceof TwigFileSource) {
+                $checkable[$name] = $source->relativeFilePath;
+
+                continue;
+            }
+
+            // Inline `#[GeneratedGraphQLFragment]` contracts are standalone
+            // entry points: treat them (and what they spread) as used.
+            $queue[] = $name;
+        }
+
+        foreach ($operations as $documents) {
+            foreach ($documents as $document) {
+                foreach ($document->definitions as $definition) {
+                    if ( ! $definition instanceof OperationDefinitionNode) {
+                        continue;
+                    }
+
+                    foreach (UsedFragmentsVisitor::getUsedFragments($definition) as $spread) {
+                        $queue[] = $spread;
+                    }
+                }
+            }
+        }
+
+        /**
+         * @var array<string, true> $reachable
+         */
+        $reachable = [];
+
+        while ($queue !== []) {
+            $name = array_pop($queue);
+
+            if (isset($reachable[$name])) {
+                continue;
+            }
+
+            $reachable[$name] = true;
+
+            foreach ($fragmentSpreads[$name] ?? [] as $dependency) {
+                if ( ! isset($reachable[$dependency])) {
+                    $queue[] = $dependency;
+                }
+            }
+        }
+
+        $unused = array_diff_key($checkable, $reachable);
+        ksort($unused);
+
+        return $unused;
     }
 
     private function anyClassUsesThrowWhenNull(PlannerResult $result) : bool

--- a/src/Planner/PlannerResult.php
+++ b/src/Planner/PlannerResult.php
@@ -37,6 +37,15 @@ final class PlannerResult
     public private(set) array $operationsToInject = [];
 
     /**
+     * Fragments defined in a `.graphql` file or a `.twig` template that are
+     * never spread by any operation (transitively). Map of fragment name to
+     * the relative source path where it is defined.
+     *
+     * @var array<string, string>
+     */
+    public private(set) array $unusedFragments = [];
+
+    /**
      * @param object $class A plan object with a path property
      */
     public function addClass(object $class) : void
@@ -74,5 +83,13 @@ final class PlannerResult
     public function setOperationsToInject(array $operationsToInject) : void
     {
         $this->operationsToInject = $operationsToInject;
+    }
+
+    /**
+     * @param array<string, string> $unusedFragments
+     */
+    public function setUnusedFragments(array $unusedFragments) : void
+    {
+        $this->unusedFragments = $unusedFragments;
     }
 }

--- a/tests/UnusedFragment/Schema.graphql
+++ b/tests/UnusedFragment/Schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+    viewer: Viewer!
+}
+
+type Viewer {
+    name: String!
+    login: String!
+}

--- a/tests/UnusedFragment/UnusedFragmentTest.php
+++ b/tests/UnusedFragment/UnusedFragmentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\UnusedFragment;
+
+use PHPUnit\Framework\TestCase;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\Planner;
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+/**
+ * Deliberately NOT a {@see \Ruudk\GraphQLCodeGenerator\GraphQLTestCase}: this
+ * fixture intentionally contains unused fragments, and the auto-discovered
+ * `--ensure-sync` run would (correctly) fail on them. Here we drive the
+ * Planner directly and assert on the detected set instead.
+ */
+final class UnusedFragmentTest extends TestCase
+{
+    private function plan() : Planner
+    {
+        $projectDir = dirname(__DIR__, 2);
+
+        $config = Config::create(
+            schema: __DIR__ . '/Schema.graphql',
+            projectDir: $projectDir,
+            outputDir: __DIR__ . '/Generated',
+            namespace: 'Ruudk\\GraphQLCodeGenerator\\UnusedFragment\\Generated',
+            client: TestClient::class,
+        )
+            ->withQueriesDir(__DIR__ . '/graphql')
+            ->withInlineProcessingDirectory(__DIR__)
+            ->withTwigProcessingDirectory(__DIR__ . '/templates');
+
+        return new Planner($config);
+    }
+
+    public function testUnusedFragmentsAreReported() : void
+    {
+        $result = $this->plan()->plan();
+
+        self::assertSame(
+            [
+                'OnlyViaOrphan' => 'tests/UnusedFragment/graphql/Orphan.graphql',
+                'OrphanFragment' => 'tests/UnusedFragment/graphql/Orphan.graphql',
+                'UnusedTwig' => 'tests/UnusedFragment/templates/widget.html.twig',
+            ],
+            $result->unusedFragments,
+        );
+    }
+
+    public function testUsedFragmentsAreNotReported() : void
+    {
+        $result = $this->plan()->plan();
+
+        // Spread by the `Test` operation, so these must never be flagged.
+        self::assertArrayNotHasKey('UsedFragment', $result->unusedFragments);
+        self::assertArrayNotHasKey('UsedTwig', $result->unusedFragments);
+    }
+}

--- a/tests/UnusedFragment/graphql/Orphan.graphql
+++ b/tests/UnusedFragment/graphql/Orphan.graphql
@@ -1,0 +1,7 @@
+fragment OrphanFragment on Viewer {
+    ...OnlyViaOrphan
+}
+
+fragment OnlyViaOrphan on Viewer {
+    login
+}

--- a/tests/UnusedFragment/graphql/Test.graphql
+++ b/tests/UnusedFragment/graphql/Test.graphql
@@ -1,0 +1,10 @@
+query Test {
+    viewer {
+        ...UsedFragment
+        ...UsedTwig
+    }
+}
+
+fragment UsedFragment on Viewer {
+    name
+}

--- a/tests/UnusedFragment/templates/widget.html.twig
+++ b/tests/UnusedFragment/templates/widget.html.twig
@@ -1,0 +1,11 @@
+{% graphql %}
+fragment UsedTwig on Viewer {
+    login
+}
+{% endgraphql %}
+
+{% graphql %}
+fragment UnusedTwig on Viewer {
+    name
+}
+{% endgraphql %}


### PR DESCRIPTION
Fragments defined in `.graphql` files or `.twig` templates were silently generated even when nothing ever spread them, leaving orphan generated classes that nobody could discover were safe to delete.

Compute reachability from operation spreads (plus inline `#[GeneratedGraphQLFragment]` contracts, which are intentionally standalone, so what they spread counts as used) through the transitive fragment-spread graph. Any file-defined fragment that is not reachable is now reported. Under `--ensure-sync` this is a hard error that fails the run after listing every offender; otherwise it is a warning and generation continues. Inline contracts themselves are out of scope — only fragments a developer can simply delete are flagged.
