### PR TITLE
Tag sole `__typename` on a list as `@api`

### DIFF
--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -1008,7 +1008,9 @@ final class SelectionSetPlanner
         $payloadShape = $result->getPayloadShapeType();
 
         // Unwrap list types
-        if ($fields instanceof SymfonyType\CollectionType && $fields->isList()) {
+        $fieldIsList = $fields instanceof SymfonyType\CollectionType && $fields->isList();
+
+        if ($fieldIsList) {
             $fields = $fields->getCollectionValueType();
         }
 
@@ -1036,30 +1038,29 @@ final class SelectionSetPlanner
             inlineFragmentRequiredFields: $this->inlineFragmentRequiredFields,
             isData: false,
             isFragment: false,
-            markTypenameAsApi: $this->isSoleTypenameOnFirstLevelMutationField($context, $selection),
+            markTypenameAsApi: $this->shouldMarkTypenameAsApi($context, $selection, $fieldIsList),
         );
 
         $this->result->addClass($dataClass);
     }
 
     /**
-     * A first-level mutation field selecting nothing but `__typename` is the
-     * idiomatic "fire and forget" mutation: the caller only wants the side
-     * effect. The generated `__typename` property is then never read, so we
-     * tag it `@api` to stop dead-code analysis from flagging it. This must
-     * NOT trigger when other fields are selected alongside `__typename`, nor
-     * when `__typename` appears deeper than the first level.
+     * Selecting nothing but `__typename` means the caller does not actually
+     * read the value back — GraphQL just forces at least one field to be
+     * selected. The generated `__typename` property is then never used, so we
+     * tag it `@api` to stop dead-code analysis from flagging it. This applies
+     * to:
+     *   - a list field (you must select something to iterate the list), and
+     *   - a first-level "fire and forget" mutation field (only the side
+     *     effect matters).
+     * It must NOT trigger when other fields are selected alongside
+     * `__typename`.
      */
-    private function isSoleTypenameOnFirstLevelMutationField(
+    private function shouldMarkTypenameAsApi(
         PlanningContext $context,
         FieldNode $selection,
+        bool $fieldIsList,
     ) : bool {
-        // Root path is the operation type ("mutation"); a first-level field
-        // is therefore exactly "mutation.<fieldName>" (one separator).
-        if ( ! str_starts_with($context->path, 'mutation.') || substr_count($context->path, '.') !== 1) {
-            return false;
-        }
-
         $selections = $selection->selectionSet?->selections;
 
         if ($selections === null || count($selections) !== 1) {
@@ -1068,7 +1069,17 @@ final class SelectionSetPlanner
 
         $only = $selections[0];
 
-        return $only instanceof FieldNode && $only->name->value === '__typename';
+        if ( ! $only instanceof FieldNode || $only->name->value !== '__typename') {
+            return false;
+        }
+
+        if ($fieldIsList) {
+            return true;
+        }
+
+        // Root path is the operation type ("mutation"); a first-level field
+        // is therefore exactly "mutation.<fieldName>" (one separator).
+        return str_starts_with($context->path, 'mutation.') && substr_count($context->path, '.') === 1;
     }
 
     private function createInlineFragmentClassPlan(

--- a/tests/ListTypename/Generated/Query/Test/Data.php
+++ b/tests/ListTypename/Generated/Query/Test/Data.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Field $field {
+        get => $this->field ??= new Field($this->data['field']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'field': array{
+     *         'multiList': list<array{
+     *             '__typename': string,
+     *             'id': string,
+     *         }>,
+     *         'single': array{
+     *             '__typename': string,
+     *         },
+     *         'soleList': list<array{
+     *             '__typename': string,
+     *         }>,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/ListTypename/Generated/Query/Test/Data/Field.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\MultiList;
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\Single;
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\SoleList;
+
+// This file was automatically generated and should not be edited.
+
+final class Field
+{
+    /**
+     * @var list<MultiList>
+     */
+    public array $multiList {
+        get => $this->multiList ??= array_map(fn($item) => new MultiList($item), $this->data['multiList']);
+    }
+
+    public Single $single {
+        get => $this->single ??= new Single($this->data['single']);
+    }
+
+    /**
+     * @var list<SoleList>
+     */
+    public array $soleList {
+        get => $this->soleList ??= array_map(fn($item) => new SoleList($item), $this->data['soleList']);
+    }
+
+    /**
+     * @param array{
+     *     'multiList': list<array{
+     *         '__typename': string,
+     *         'id': string,
+     *     }>,
+     *     'single': array{
+     *         '__typename': string,
+     *     },
+     *     'soleList': list<array{
+     *         '__typename': string,
+     *     }>,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/MultiList.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/MultiList.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field;
+
+// This file was automatically generated and should not be edited.
+
+final class MultiList
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field;
+
+// This file was automatically generated and should not be edited.
+
+final class Single
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/SoleList.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/SoleList.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field;
+
+// This file was automatically generated and should not be edited.
+
+final class SoleList
+{
+    /**
+     * @api
+     */
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/ListTypename/Generated/Query/Test/Error.php
+++ b/tests/ListTypename/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/ListTypename/Generated/Query/Test/TestQuery.php
+++ b/tests/ListTypename/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          field {
+            soleList {
+              __typename
+            }
+            multiList {
+              __typename
+              id
+            }
+            single {
+              __typename
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/ListTypename/ListTypenameTest.php
+++ b/tests/ListTypename/ListTypenameTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\ListTypename;
+
+use ReflectionClass;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\MultiList;
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\Single;
+use Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Field\SoleList;
+
+final class ListTypenameTest extends GraphQLTestCase
+{
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    /**
+     * A list whose only selection is __typename is selected purely because
+     * GraphQL forces at least one field; the value is never read, so the
+     * property is tagged @api.
+     */
+    public function testSoleTypenameOnListIsApi() : void
+    {
+        $docComment = new ReflectionClass(SoleList::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
+    }
+
+    /**
+     * Other fields are selected alongside __typename, so the caller does
+     * read the list items: it must NOT be tagged @api.
+     */
+    public function testTypenameWithSiblingFieldsOnListIsNotApi() : void
+    {
+        $docComment = new ReflectionClass(MultiList::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+    }
+
+    /**
+     * The rule is list-specific: a sole __typename on a non-list nested
+     * object (and not a first-level mutation field) is not tagged @api.
+     */
+    public function testSoleTypenameOnSingleObjectIsNotApi() : void
+    {
+        $docComment = new ReflectionClass(Single::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+    }
+}

--- a/tests/ListTypename/Schema.graphql
+++ b/tests/ListTypename/Schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+    field: Field!
+}
+
+type Field {
+    soleList: [Item!]!
+    multiList: [Item!]!
+    single: Item!
+}
+
+type Item {
+    id: ID!
+    name: String!
+}

--- a/tests/ListTypename/Test.graphql
+++ b/tests/ListTypename/Test.graphql
@@ -1,0 +1,14 @@
+query Test {
+    field {
+        soleList {
+            __typename
+        }
+        multiList {
+            __typename
+            id
+        }
+        single {
+            __typename
+        }
+    }
+}


### PR DESCRIPTION
Selecting nothing but `__typename` on a list field is done only because GraphQL forces at least one field to be selected; the value is never read back, so the generated property would be flagged as unused by tools like shipmonk/dead-code-detector.

Generalise the existing fire-and-forget-mutation rule: a sole `__typename` selection is tagged `@api` when the field is a list, in addition to the first-level mutation case. Selecting other fields alongside `__typename`, or a sole `__typename` on a non-list nested object, is left untagged.
