### PR TITLE
Add Twig CS Fixer rule to auto-format GraphQL blocks

### DIFF
--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
+use Ruudk\GraphQLCodeGenerator\Twig\GraphQLFormatterRule;
 use Ruudk\GraphQLCodeGenerator\Twig\GraphQLTokenParser;
+use TwigCsFixer\Config\Config;
+use TwigCsFixer\File\Finder;
 use TwigCsFixer\Ruleset\Ruleset;
 use TwigCsFixer\Standard\TwigCsFixer;
-use TwigCsFixer\File\Finder;
-use TwigCsFixer\Config\Config;
 
 $ruleset = new Ruleset();
 
 $ruleset->addStandard(new TwigCsFixer());
+$ruleset->addRule(new GraphQLFormatterRule());
 
 $finder = Finder::create()
     ->in('tests');
@@ -21,4 +25,3 @@ $config->setFinder($finder);
 $config->addTokenParser(new GraphQLTokenParser());
 
 return $config;
-

--- a/README.md
+++ b/README.md
@@ -599,6 +599,45 @@ fragment AdminProjectRow on Project {
 
 The generator extracts fragments from Twig files and creates type-safe classes. Your templates and GraphQL stay together!
 
+#### 🧹 Auto-Format GraphQL in Twig
+
+A [Twig CS Fixer](https://github.com/VincentLanglet/Twig-CS-Fixer) rule ships with this library to keep the GraphQL inside your `{% graphql %}` blocks consistently formatted. It parses the operation and rewrites it with `webonyx/graphql-php`'s `Printer::doPrint()`, re-indented to match the block. Invalid GraphQL is reported as an error and left untouched, and blocks that embed Twig are skipped.
+
+Register `GraphQLFormatterRule` (and the `GraphQLTokenParser` so Twig CS Fixer understands the tag) in your `.twig-cs-fixer.php`:
+
+<!-- source: .twig-cs-fixer.php -->
+```php
+<?php
+
+declare(strict_types=1);
+
+use Ruudk\GraphQLCodeGenerator\Twig\GraphQLFormatterRule;
+use Ruudk\GraphQLCodeGenerator\Twig\GraphQLTokenParser;
+use TwigCsFixer\Config\Config;
+use TwigCsFixer\File\Finder;
+use TwigCsFixer\Ruleset\Ruleset;
+use TwigCsFixer\Standard\TwigCsFixer;
+
+$ruleset = new Ruleset();
+
+$ruleset->addStandard(new TwigCsFixer());
+$ruleset->addRule(new GraphQLFormatterRule());
+
+$finder = Finder::create()
+    ->in('tests');
+
+$config = new Config();
+$config->allowNonFixableRules();
+$config->setCacheFile(__DIR__ . '/.twig-cs-fixer.cache');
+$config->setRuleset($ruleset);
+$config->setFinder($finder);
+$config->addTokenParser(new GraphQLTokenParser());
+
+return $config;
+```
+
+Running `vendor/bin/twig-cs-fixer fix` now formats every `{% graphql %}` block automatically, and `vendor/bin/twig-cs-fixer lint` fails on any block that isn't canonically formatted.
+
 ### ⚡ Custom `@indexBy` Directive
 
 Stop searching through arrays—index collections by a field for O(1) lookups:

--- a/README.md
+++ b/README.md
@@ -582,10 +582,10 @@ Keep your GraphQL fragments next to where they're used in your templates:
 
 {% graphql %}
 fragment AdminProjectRow on Project {
-    id
-    name
-    description
-    ...AdminProjectOptions
+  id
+  name
+  description
+  ...AdminProjectOptions
 }
 {% endgraphql %}
 

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -10,6 +10,7 @@ $config = new Configuration();
 $config->addPathToScan(__DIR__ . '/bin', isDev: false);
 
 $config->ignoreErrorsOnPackage('twig/twig', [ErrorType::DEV_DEPENDENCY_IN_PROD]);
+$config->ignoreErrorsOnPackage('vincentlanglet/twig-cs-fixer', [ErrorType::DEV_DEPENDENCY_IN_PROD]);
 
 // phpstan/phpdoc-parser is never referenced directly. Symfony's TypeResolver
 // only enables @return / @param PHPDoc parsing when this package is loadable,

--- a/src/Twig/GraphQLFormatterRule.php
+++ b/src/Twig/GraphQLFormatterRule.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Twig;
+
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Printer;
+use JsonException;
+use Override;
+use TwigCsFixer\Rules\AbstractFixableRule;
+use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
+
+/**
+ * Formats the GraphQL operations inside `{% graphql %}...{% endgraphql %}`
+ * blocks using webonyx/graphql-php so they follow a single canonical style.
+ */
+final class GraphQLFormatterRule extends AbstractFixableRule
+{
+    #[Override]
+    protected function process(int $tokenIndex, Tokens $tokens) : void
+    {
+        $token = $tokens->get($tokenIndex);
+
+        if ( ! $token->isMatching(Token::BLOCK_NAME_TYPE, 'graphql')) {
+            return;
+        }
+
+        $blockEndIndex = $tokens->findNext(Token::BLOCK_END_TYPE, $tokenIndex);
+
+        if ($blockEndIndex === false) {
+            return;
+        }
+
+        $endNameIndex = false;
+
+        for ($i = $blockEndIndex + 1; $tokens->has($i); ++$i) {
+            if ($tokens->get($i)->isMatching(Token::BLOCK_NAME_TYPE, 'endgraphql')) {
+                $endNameIndex = $i;
+
+                break;
+            }
+        }
+
+        if ($endNameIndex === false) {
+            return;
+        }
+
+        $endBlockStartIndex = $tokens->findPrevious(Token::BLOCK_START_TYPE, $endNameIndex, $blockEndIndex);
+
+        if ($endBlockStartIndex === false) {
+            return;
+        }
+
+        $contentStart = $blockEndIndex + 1;
+        $contentEnd = $endBlockStartIndex - 1;
+
+        if ($contentStart > $contentEnd) {
+            return;
+        }
+
+        $raw = '';
+
+        for ($i = $contentStart; $i <= $contentEnd; ++$i) {
+            $contentToken = $tokens->get($i);
+
+            // Bail out when the block embeds Twig (variables, tags, comments);
+            // reconstructing the original source from those tokens is not safe.
+            if ($contentToken->isMatching([
+                Token::BLOCK_START_TYPE,
+                Token::VAR_START_TYPE,
+                Token::COMMENT_START_TYPE,
+                Token::INLINE_COMMENT_START_TYPE,
+            ])) {
+                return;
+            }
+
+            $raw .= $contentToken->getValue();
+        }
+
+        if (trim($raw) === '') {
+            return;
+        }
+
+        try {
+            $formatted = rtrim(Printer::doPrint(Parser::parse($raw)), "\r\n");
+        } catch (JsonException | SyntaxError $error) {
+            $this->addError(
+                sprintf('Unable to parse GraphQL: %s', $error->getMessage()),
+                $token,
+            );
+
+            return;
+        }
+
+        $indent = $this->resolveIndent($tokens, $tokenIndex);
+
+        $expected = "\n";
+
+        foreach (explode("\n", $formatted) as $line) {
+            $expected .= ($line === '' ? '' : $indent . $line) . "\n";
+        }
+
+        $expected .= $indent;
+
+        if ($raw === $expected) {
+            return;
+        }
+
+        $fixer = $this->addFixableError(
+            'The GraphQL operation is not correctly formatted.',
+            $token,
+        );
+
+        if ($fixer === null) {
+            return;
+        }
+
+        $fixer->beginChangeSet();
+        $fixer->replaceToken($contentStart, $expected);
+
+        for ($i = $contentStart + 1; $i <= $contentEnd; ++$i) {
+            $fixer->replaceToken($i, '');
+        }
+
+        $fixer->endChangeSet();
+    }
+
+    private function resolveIndent(Tokens $tokens, int $blockNameIndex) : string
+    {
+        $blockStartIndex = $tokens->findPrevious(Token::BLOCK_START_TYPE, $blockNameIndex);
+
+        if ($blockStartIndex === false || ! $tokens->has($blockStartIndex - 1)) {
+            return '';
+        }
+
+        $previous = $tokens->get($blockStartIndex - 1);
+
+        if ($previous->isMatching(Token::INDENT_TOKENS)) {
+            return $previous->getValue();
+        }
+
+        return '';
+    }
+}

--- a/tests/GraphQLFormatterRule/GraphQLFormatterRuleTest.php
+++ b/tests/GraphQLFormatterRule/GraphQLFormatterRuleTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQLFormatterRule;
+
+use PHPUnit\Framework\TestCase;
+use Ruudk\GraphQLCodeGenerator\Twig\GraphQLFormatterRule;
+use SplFileInfo;
+use TwigCsFixer\Environment\StubbedEnvironment;
+use TwigCsFixer\Report\Report;
+use TwigCsFixer\Report\Violation;
+use TwigCsFixer\Ruleset\Ruleset;
+use TwigCsFixer\Runner\Fixer;
+use TwigCsFixer\Runner\Linter;
+use TwigCsFixer\Token\Tokenizer;
+
+final class GraphQLFormatterRuleTest extends TestCase
+{
+    private const string TEMPLATES = __DIR__ . '/templates';
+
+    public function testFixesUnformattedGraphQLBlocks() : void
+    {
+        $unformatted = (string) file_get_contents(self::TEMPLATES . '/unformatted.html.twig.fixture');
+        $expected = (string) file_get_contents(self::TEMPLATES . '/formatted.html.twig.fixture');
+
+        self::assertSame($expected, $this->fix($unformatted));
+    }
+
+    public function testAlreadyFormattedBlocksAreLeftUnchanged() : void
+    {
+        $formatted = (string) file_get_contents(self::TEMPLATES . '/formatted.html.twig.fixture');
+
+        self::assertSame($formatted, $this->fix($formatted));
+        self::assertSame([], $this->lint(self::TEMPLATES . '/formatted.html.twig.fixture')->getViolations());
+    }
+
+    public function testReportsViolationForUnformattedBlock() : void
+    {
+        $violations = $this->lint(self::TEMPLATES . '/unformatted.html.twig.fixture')->getViolations();
+
+        self::assertCount(1, $violations);
+        self::assertSame(Violation::LEVEL_ERROR, $violations[0]->getLevel());
+        self::assertSame('The GraphQL operation is not correctly formatted.', $violations[0]->getMessage());
+    }
+
+    public function testReportsErrorForInvalidGraphQL() : void
+    {
+        $invalid = (string) file_get_contents(self::TEMPLATES . '/invalid.html.twig.fixture');
+
+        self::assertSame($invalid, $this->fix($invalid), 'Invalid GraphQL must be left untouched.');
+
+        $violations = $this->lint(self::TEMPLATES . '/invalid.html.twig.fixture')->getViolations();
+
+        self::assertCount(1, $violations);
+        self::assertSame(Violation::LEVEL_ERROR, $violations[0]->getLevel());
+        self::assertStringContainsString('Unable to parse GraphQL', $violations[0]->getMessage());
+    }
+
+    private function fix(string $content) : string
+    {
+        $fixer = new Fixer(new Tokenizer(new StubbedEnvironment()));
+
+        return $fixer->fixFile($content, $this->ruleset());
+    }
+
+    private function lint(string $filePath) : Report
+    {
+        $env = new StubbedEnvironment();
+        $linter = new Linter($env, new Tokenizer($env));
+
+        return $linter->run([new SplFileInfo($filePath)], $this->ruleset());
+    }
+
+    private function ruleset() : Ruleset
+    {
+        $ruleset = new Ruleset();
+        $ruleset->addRule(new GraphQLFormatterRule());
+
+        return $ruleset;
+    }
+}

--- a/tests/GraphQLFormatterRule/templates/formatted.html.twig.fixture
+++ b/tests/GraphQLFormatterRule/templates/formatted.html.twig.fixture
@@ -1,0 +1,11 @@
+<div>
+    {% graphql %}
+    query GetUser($id: ID!) {
+      user(id: $id) {
+        id
+        name
+        email
+      }
+    }
+    {% endgraphql %}
+</div>

--- a/tests/GraphQLFormatterRule/templates/invalid.html.twig.fixture
+++ b/tests/GraphQLFormatterRule/templates/invalid.html.twig.fixture
@@ -1,0 +1,4 @@
+{% graphql %}
+query GetUser($id: ID! {
+    user(id: $id
+{% endgraphql %}

--- a/tests/GraphQLFormatterRule/templates/unformatted.html.twig.fixture
+++ b/tests/GraphQLFormatterRule/templates/unformatted.html.twig.fixture
@@ -1,0 +1,8 @@
+<div>
+    {% graphql %}
+        query  GetUser($id:ID!){
+        user(id:$id){ id   name
+            email }
+        }
+    {% endgraphql %}
+</div>

--- a/tests/Twig/templates/_project_options.html.twig
+++ b/tests/Twig/templates/_project_options.html.twig
@@ -4,7 +4,7 @@
 
 {% graphql %}
 fragment AdminProjectOptions on Project {
-    state
+  state
 }
 {% endgraphql %}
 

--- a/tests/Twig/templates/_project_row.html.twig
+++ b/tests/Twig/templates/_project_row.html.twig
@@ -4,10 +4,10 @@
 
 {% graphql %}
 fragment AdminProjectRow on Project {
-    id
-    name
-    description
-    ...AdminProjectOptions
+  id
+  name
+  description
+  ...AdminProjectOptions
 }
 {% endgraphql %}
 

--- a/tests/Twig/templates/list.html.twig
+++ b/tests/Twig/templates/list.html.twig
@@ -4,12 +4,12 @@
 
 {% graphql %}
 fragment AdminProjectList on Query {
-    viewer {
-        name
-    }
-    projects {
-        ...AdminProjectRow
-    }
+  viewer {
+    name
+  }
+  projects {
+    ...AdminProjectRow
+  }
 }
 {% endgraphql %}
 

--- a/tests/UnusedFragment/templates/widget.html.twig
+++ b/tests/UnusedFragment/templates/widget.html.twig
@@ -1,11 +1,11 @@
 {% graphql %}
 fragment UsedTwig on Viewer {
-    login
+  login
 }
 {% endgraphql %}
 
 {% graphql %}
 fragment UnusedTwig on Viewer {
-    name
+  name
 }
 {% endgraphql %}


### PR DESCRIPTION
## Summary

Adds a Twig CS Fixer fixer that automatically formats the GraphQL operations inside `{% graphql %}...{% endgraphql %}` blocks in Twig templates.

- **`src/Twig/GraphQLFormatterRule.php`** — a fixable Twig CS Fixer rule that reconstructs the raw GraphQL from a block, reformats it via `GraphQL\Language\Printer::doPrint(Parser::parse(...))`, and re-indents every line to match the block's own indentation. Unparseable GraphQL is reported as an error and left untouched; blocks that embed Twig (variables/tags/comments) are skipped since they can't be safely round-tripped.
- Registered in `.twig-cs-fixer.php`, and the existing project templates were normalized to the canonical 2-space `webonyx/graphql-php` format (README auto-synced to match).
- Added the `vincentlanglet/twig-cs-fixer` dev-dependency-in-prod exception in `composer-dependency-analyser.php`, mirroring the existing `twig/twig` entry.
- Documented in the README under a new "Auto-Format GraphQL in Twig" section, with the `.twig-cs-fixer.php` config kept in sync via the `readme-examples-sync` source directive.

## Test plan

- [x] `tests/GraphQLFormatterRule/GraphQLFormatterRuleTest.php` — functional test driving the real twig-cs-fixer `Linter`/`Fixer` pipeline over fixture templates:
  - unformatted block → fixed to canonical output
  - already-formatted block → idempotent, zero violations
  - unformatted block → one error violation reported
  - invalid GraphQL → error reported, content left unchanged
- [x] Fixtures use a `.html.twig.fixture` extension so the pre-commit `twig-cs-fixer fix` hook (globs `*.twig`) can't mutate the intentionally-malformed inputs
- [x] Full suite green: PHPUnit (159 tests), PHPStan, php-cs-fixer, twig-cs-fixer lint, composer-dependency-analyser

https://claude.ai/code/session_0172zkGgfrZ2KQ8ngMJ1X3zr

---
_Generated by [Claude Code](https://claude.ai/code/session_0172zkGgfrZ2KQ8ngMJ1X3zr)_