### PR TITLE
Stop merging parent fields into inline-fragment classes

### DIFF
--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
@@ -14,10 +14,6 @@ namespace Ruudk\GraphQLCodeGenerator\Examples\Generated\Query\Search\Data\Search
  */
 final class AsIssue
 {
-    public string $__typename {
-        get => $this->__typename ??= $this->data['__typename'];
-    }
-
     public int $number {
         get => $this->number ??= $this->data['number'];
     }

--- a/src/Planner/FieldCollection.php
+++ b/src/Planner/FieldCollection.php
@@ -28,22 +28,8 @@ final class FieldCollection
         return $this->fields[$name];
     }
 
-    public function merge(FieldCollection $other) : self
-    {
-        foreach ($other->fields as $name => $type) {
-            $this->fields[$name] = $type;
-        }
-
-        return $this;
-    }
-
     public function toArrayShape() : SymfonyType
     {
         return SymfonyType::arrayShape($this->fields);
-    }
-
-    public function clone() : self
-    {
-        return clone $this;
     }
 }

--- a/src/Planner/PayloadShape.php
+++ b/src/Planner/PayloadShape.php
@@ -130,9 +130,4 @@ final class PayloadShape
     {
         return SymfonyType::arrayShape($this->shape);
     }
-
-    public function clone() : self
-    {
-        return clone $this;
-    }
 }

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -266,10 +266,6 @@ final class SelectionSetPlanner
             );
         }
 
-        // Store state before inline fragments for merging
-        $fieldsBeforeInlineFragments = $fields->clone();
-        $payloadShapeBeforeInlineFragments = $payloadShape->clone();
-
         // Process inline fragments
         foreach ($selectionSet->selections as $selection) {
             if ( ! $selection instanceof InlineFragmentNode) {
@@ -284,9 +280,6 @@ final class SelectionSetPlanner
                 $fields,
                 $pathFields,
                 $payloadShape,
-                $fieldsBeforeInlineFragments,
-                $payloadShapeBeforeInlineFragments,
-                $selectionSet,
             );
         }
 
@@ -534,9 +527,6 @@ final class SelectionSetPlanner
         FieldCollection $fields,
         PathFieldMap $pathFields,
         PayloadShape $payloadShape,
-        FieldCollection $fieldsBeforeInlineFragments,
-        PayloadShape $payloadShapeBeforeInlineFragments,
-        SelectionSetNode $parentSelectionSet,
     ) : void {
         Assert::notNull($selection->typeCondition, 'Inline fragment must have a type condition');
 
@@ -558,15 +548,11 @@ final class SelectionSetPlanner
             $fragmentContext,
         );
 
-        // Merge parent fields into fragment
-        $mergedFields = $fieldsBeforeInlineFragments->clone();
-        $mergedFields->merge($fragmentResult->fields);
-
-        $mergedPayloadShape = $payloadShapeBeforeInlineFragments->clone();
-        $mergedPayloadShape->merge($fragmentResult->payloadShape);
-
-        // For the inline fragment class itself, build a payload shape where fields are required
-        // We need to include both parent fields and inline fragment fields
+        // The inline-fragment class only exposes what is selected inside
+        // `... on Type { ... }`. Parent fields are deliberately NOT merged in:
+        // doing so made it impossible to tell which interface-level fields a
+        // given variant actually consumes (over-fetch detection). If a field
+        // is needed on the variant it must be selected within the fragment.
         $fragmentSpecificBuilder = new PayloadShapeBuilder(
             $this->schema,
             $this->typeMapper,
@@ -574,35 +560,8 @@ final class SelectionSetPlanner
             $this->fragmentTypes,
         );
 
-        // First, get the parent fields that apply to this type
-        // We need to filter out inline fragments and fragment spreads that are for other types
-        $parentSelectionsForThisType = [];
-        foreach ($parentSelectionSet->selections as $parentSelection) {
-            if ($parentSelection instanceof FieldNode) {
-                // Direct field selections always apply
-                $parentSelectionsForThisType[] = $parentSelection;
-            } elseif ($parentSelection instanceof InlineFragmentNode && $parentSelection === $selection) {
-                // This is the current inline fragment we're processing - skip it to avoid duplication
-                continue;
-            } elseif ($parentSelection instanceof FragmentSpreadNode) {
-                // Fragment spreads should NOT be included in inline fragment classes
-                // They are isolated and accessed through their own accessor
-                continue;
-            }
-            // Skip other inline fragments - they're for different types
-        }
-
-        // Create a combined selection set with parent fields and this inline fragment's fields
-        $combinedSelectionSet = new SelectionSetNode([
-            'selections' => new NodeList([
-                ...$parentSelectionsForThisType,
-                ...$selection->selectionSet->selections,
-            ]),
-        ]);
-
-        // Build the payload shape with the combined selections
-        // Using fragmentType as parent ensures fields won't be marked optional
-        $inlineFragmentPayloadShape = $fragmentSpecificBuilder->buildPayloadShape($combinedSelectionSet, $fragmentType);
+        // Using fragmentType as parent ensures fields won't be marked optional.
+        $inlineFragmentPayloadShape = $fragmentSpecificBuilder->buildPayloadShape($selection->selectionSet, $fragmentType);
 
         // Add __typename as it's always present for inline fragments
         if ( ! $inlineFragmentPayloadShape->has('__typename')) {
@@ -616,7 +575,7 @@ final class SelectionSetPlanner
         $this->createInlineFragmentClassPlan(
             $source,
             $fragmentType,
-            $mergedFields,
+            $fragmentResult->fields,
             $inlineFragmentPayloadShape,
             $fragmentContext,
             $selection,

--- a/tests/ExplicitTypename/ExplicitTypenameTest.php
+++ b/tests/ExplicitTypename/ExplicitTypenameTest.php
@@ -48,9 +48,10 @@ final class ExplicitTypenameTest extends GraphQLTestCase
     }
 
     /**
-     * The explicit __typename also propagates into the inline-fragment class
-     * (AsApplication), which is one of the classes that discriminates on
-     * `$this->data['__typename']`, so it must expose the property there too.
+     * Inline-fragment variant classes only expose what is selected inside
+     * `... on Application { ... }` (parent/interface fields are NOT merged
+     * in). Selecting `__typename`, `url` and `name` there means the
+     * generated `AsApplication` exposes exactly those.
      */
     public function testExplicitTypenameOnInlineFragmentVariant() : void
     {

--- a/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
@@ -29,6 +29,10 @@ final class Viewer
                 return $this->asApplication = null;
             }
 
+            if (! array_key_exists('name', $this->data)) {
+                return $this->asApplication = null;
+            }
+
             return $this->asApplication = new AsApplication($this->data);
         }
     }

--- a/tests/ExplicitTypename/Generated/Query/Test/TestQuery.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/TestQuery.php
@@ -17,7 +17,9 @@ final readonly class TestQuery {
             name
             ...UserDetails
             ... on Application {
+              __typename
               url
+              name
             }
           }
         }

--- a/tests/ExplicitTypename/Test.graphql
+++ b/tests/ExplicitTypename/Test.graphql
@@ -4,7 +4,9 @@ query Test {
         name
         ...UserDetails
         ...on Application {
+            __typename
             url
+            name
         }
     }
 }

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
@@ -26,6 +26,10 @@ final class Thing
                 return $this->asVariantA = null;
             }
 
+            if (! array_key_exists('id', $this->data)) {
+                return $this->asVariantA = null;
+            }
+
             if (! array_key_exists('realFieldA', $this->data)) {
                 return $this->asVariantA = null;
             }

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
@@ -11,10 +11,6 @@ use Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\User;
 
 final class AsVariantA
 {
-    public string $__typename {
-        get => $this->__typename ??= $this->data['__typename'];
-    }
-
     public string $id {
         get => $this->id ??= $this->data['id'];
     }

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
@@ -8,14 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\HooksInUnionVariant\Generated\Query\Test\Da
 
 final class AsVariantB
 {
-    public string $__typename {
-        get => $this->__typename ??= $this->data['__typename'];
-    }
-
-    public string $id {
-        get => $this->id ??= $this->data['id'];
-    }
-
     public string $realFieldB {
         get => $this->realFieldB ??= $this->data['realFieldB'];
     }
@@ -23,7 +15,6 @@ final class AsVariantB
     /**
      * @param array{
      *     '__typename': 'VariantB',
-     *     'id': string,
      *     'realFieldB': string,
      * } $data
      */

--- a/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
@@ -17,6 +17,7 @@ final readonly class TestQuery {
             __typename
             id
             ... on VariantA {
+              id
               realFieldA
             }
             ... on VariantB {

--- a/tests/HooksInUnionVariant/Test.graphql
+++ b/tests/HooksInUnionVariant/Test.graphql
@@ -3,6 +3,7 @@ query Test {
         __typename
         id
         ... on VariantA {
+            id
             realFieldA
             user @hook(name: "findUserById", input: ["id"])
         }

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
@@ -8,10 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\V
 
 final class AsApplication
 {
-    public string $name {
-        get => $this->name ??= $this->data['name'];
-    }
-
     public string $url {
         get => $this->url ??= $this->data['url'];
     }
@@ -19,7 +15,6 @@ final class AsApplication
     /**
      * @param array{
      *     '__typename': 'Application',
-     *     'name': string,
      *     'url': string,
      * } $data
      */

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -12,15 +12,10 @@ final class AsUser
         get => $this->login ??= $this->data['login'];
     }
 
-    public string $name {
-        get => $this->name ??= $this->data['name'];
-    }
-
     /**
      * @param array{
      *     '__typename': 'User',
      *     'login': string,
-     *     'name': string,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/InlineFragmentsTest.php
+++ b/tests/InlineFragments/InlineFragmentsTest.php
@@ -7,6 +7,8 @@ namespace Ruudk\GraphQLCodeGenerator\InlineFragments;
 use ReflectionClass;
 use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
 use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\Viewer;
+use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\Viewer\AsApplication;
+use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\Viewer\AsUser;
 use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\TestQuery;
 
 final class InlineFragmentsTest extends GraphQLTestCase
@@ -37,6 +39,24 @@ final class InlineFragmentsTest extends GraphQLTestCase
 
         self::assertTrue($result->viewer->isUser);
         self::assertSame('ruudk', $result->viewer->asUser?->login);
+    }
+
+    /**
+     * The query selects `name` at the interface level. Interface/parent
+     * fields are NOT merged into the inline-fragment variant classes: a
+     * variant exposes only what is selected inside its own
+     * `... on Type { ... }`. To read `name` on a variant it must be
+     * selected within that variant.
+     */
+    public function testParentFieldsAreNotMergedIntoVariantClasses() : void
+    {
+        $asUser = new ReflectionClass(AsUser::class);
+        self::assertTrue($asUser->hasProperty('login'));
+        self::assertFalse($asUser->hasProperty('name'), 'Parent field "name" must not leak into AsUser');
+
+        $asApplication = new ReflectionClass(AsApplication::class);
+        self::assertTrue($asApplication->hasProperty('url'));
+        self::assertFalse($asApplication->hasProperty('name'), 'Parent field "name" must not leak into AsApplication');
     }
 
     public function testGenerate() : void

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -8,14 +8,6 @@ namespace Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test\Data\View
 
 final class AsUser
 {
-    public string $id {
-        get => $this->id ??= $this->data['id'];
-    }
-
-    public string $idAlias {
-        get => $this->idAlias ??= $this->data['idAlias'];
-    }
-
     public string $login {
         get => $this->login ??= $this->data['login'];
     }
@@ -27,8 +19,6 @@ final class AsUser
     /**
      * @param array{
      *     '__typename': 'User',
-     *     'id': string,
-     *     'idAlias': string,
      *     'login': string,
      *     'name': string,
      * } $data


### PR DESCRIPTION
When a query selected interface-level fields alongside inline fragments (`viewer { name ... on Application { url } }`), those parent fields were silently merged into every `As<Type>` variant class. That made it impossible to see which fields a given variant actually consumes, so over-fetching and unused selections on a variant could not be detected.

An inline-fragment class now exposes only what is selected inside its own `... on Type { ... }`. If a field is needed on a variant it must be selected there. This is a deliberate behaviour break (no compatibility shim). `FieldCollection::merge`/`clone` and `PayloadShape::clone` had no remaining callers and were removed.
