### PR TITLE
Mark __typename as @api in inline fragments with sole typename

### DIFF
--- a/src/Planner/Plan/DataClassPlan.php
+++ b/src/Planner/Plan/DataClassPlan.php
@@ -43,11 +43,12 @@ final class DataClassPlan
         public readonly bool $isData,
         public readonly bool $isFragment,
         /**
-         * True when this class is a first-level mutation field whose only
-         * selection is an explicitly queried `__typename`. Such a selection
-         * is the idiomatic way to fire a mutation without caring about the
-         * response, so the generated `__typename` property is tagged `@api`
-         * to keep dead-code analysis from flagging it.
+         * True when the only selection on this class is an explicitly
+         * queried `__typename` (a first-level "fire and forget" mutation
+         * field, a list field, or an inline fragment such as
+         * `... on SupportedCountryError { __typename }`). The value is not
+         * read back, so the generated `__typename` property is tagged
+         * `@api` to keep dead-code analysis from flagging it.
          */
         public readonly bool $markTypenameAsApi = false,
     ) {}

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -1020,15 +1020,7 @@ final class SelectionSetPlanner
         FieldNode $selection,
         bool $fieldIsList,
     ) : bool {
-        $selections = $selection->selectionSet?->selections;
-
-        if ($selections === null || count($selections) !== 1) {
-            return false;
-        }
-
-        $only = $selections[0];
-
-        if ( ! $only instanceof FieldNode || $only->name->value !== '__typename') {
+        if ( ! $this->selectionSetIsSoleTypename($selection->selectionSet)) {
             return false;
         }
 
@@ -1039,6 +1031,25 @@ final class SelectionSetPlanner
         // Root path is the operation type ("mutation"); a first-level field
         // is therefore exactly "mutation.<fieldName>" (one separator).
         return str_starts_with($context->path, 'mutation.') && substr_count($context->path, '.') === 1;
+    }
+
+    /**
+     * True when the only thing selected is an explicitly queried
+     * `__typename`. Selecting nothing else means the caller does not read
+     * the value back (GraphQL just forces at least one field), so the
+     * generated `__typename` property is never used.
+     */
+    private function selectionSetIsSoleTypename(?SelectionSetNode $selectionSet) : bool
+    {
+        $selections = $selectionSet?->selections;
+
+        if ($selections === null || count($selections) !== 1) {
+            return false;
+        }
+
+        $only = $selections[0];
+
+        return $only instanceof FieldNode && $only->name->value === '__typename';
     }
 
     private function createInlineFragmentClassPlan(
@@ -1062,6 +1073,7 @@ final class SelectionSetPlanner
             inlineFragmentRequiredFields: $this->inlineFragmentRequiredFields,
             isData: false,
             isFragment: true,
+            markTypenameAsApi: $this->selectionSetIsSoleTypename($selection->selectionSet),
         );
 
         $this->result->addClass($dataClass);

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test;
+
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    /**
+     * @api
+     */
+    public AddCountry $addCountry {
+        get => $this->addCountry ??= new AddCountry($this->data['addCountry']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'addCountry': array{
+     *         '__typename': string,
+     *         'code'?: string,
+     *         'id'?: string,
+     *         'name'?: string,
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry\AsCountry;
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry\AsSupportedCountryError;
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry\AsUnsupportedCountryError;
+
+// This file was automatically generated and should not be edited.
+
+final class AddCountry
+{
+    public ?AsCountry $asCountry {
+        get {
+            if (isset($this->asCountry)) {
+                return $this->asCountry;
+            }
+
+            if ($this->data['__typename'] !== 'Country') {
+                return $this->asCountry = null;
+            }
+
+            if (! array_key_exists('id', $this->data)) {
+                return $this->asCountry = null;
+            }
+
+            if (! array_key_exists('name', $this->data)) {
+                return $this->asCountry = null;
+            }
+
+            return $this->asCountry = new AsCountry($this->data);
+        }
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asCountry
+     */
+    public bool $isCountry {
+        get => $this->isCountry ??= $this->data['__typename'] === 'Country';
+    }
+
+    public ?AsSupportedCountryError $asSupportedCountryError {
+        get => $this->asSupportedCountryError ??= $this->data['__typename'] === 'SupportedCountryError' ? new AsSupportedCountryError($this->data) : null;
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asSupportedCountryError
+     */
+    public bool $isSupportedCountryError {
+        get => $this->isSupportedCountryError ??= $this->data['__typename'] === 'SupportedCountryError';
+    }
+
+    public ?AsUnsupportedCountryError $asUnsupportedCountryError {
+        get {
+            if (isset($this->asUnsupportedCountryError)) {
+                return $this->asUnsupportedCountryError;
+            }
+
+            if ($this->data['__typename'] !== 'UnsupportedCountryError') {
+                return $this->asUnsupportedCountryError = null;
+            }
+
+            if (! array_key_exists('code', $this->data)) {
+                return $this->asUnsupportedCountryError = null;
+            }
+
+            return $this->asUnsupportedCountryError = new AsUnsupportedCountryError($this->data);
+        }
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asUnsupportedCountryError
+     */
+    public bool $isUnsupportedCountryError {
+        get => $this->isUnsupportedCountryError ??= $this->data['__typename'] === 'UnsupportedCountryError';
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     *     'code'?: string,
+     *     'id'?: string,
+     *     'name'?: string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsCountry.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsCountry.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class AsCountry
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'Country',
+     *     'id': string,
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsSupportedCountryError.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsSupportedCountryError.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class AsSupportedCountryError
+{
+    /**
+     * @api
+     */
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'SupportedCountryError',
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsUnsupportedCountryError.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsUnsupportedCountryError.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class AsUnsupportedCountryError
+{
+    public string $__typename {
+        get => $this->__typename ??= $this->data['__typename'];
+    }
+
+    public string $code {
+        get => $this->code ??= $this->data['code'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'UnsupportedCountryError',
+     *     'code': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Error.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/TestMutation.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/TestMutation.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestMutation {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        mutation Test {
+          addCountry {
+            __typename
+            ... on Country {
+              id
+              name
+            }
+            ... on SupportedCountryError {
+              __typename
+            }
+            ... on UnsupportedCountryError {
+              __typename
+              code
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/InlineFragmentTypename/InlineFragmentTypenameTest.php
+++ b/tests/InlineFragmentTypename/InlineFragmentTypenameTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\InlineFragmentTypename;
+
+use ReflectionClass;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry\AsSupportedCountryError;
+use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Data\AddCountry\AsUnsupportedCountryError;
+
+final class InlineFragmentTypenameTest extends GraphQLTestCase
+{
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    /**
+     * `... on SupportedCountryError { __typename }` selects nothing the
+     * caller reads back, so the generated __typename property is tagged
+     * @api, just like a sole __typename on a fire-and-forget mutation.
+     */
+    public function testSoleTypenameOnInlineFragmentIsApi() : void
+    {
+        $docComment = new ReflectionClass(AsSupportedCountryError::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
+    }
+
+    /**
+     * An inline fragment that selects real fields alongside __typename is
+     * data the caller asked for; __typename must NOT be tagged @api.
+     */
+    public function testTypenameWithSiblingFieldsIsNotApi() : void
+    {
+        $docComment = new ReflectionClass(AsUnsupportedCountryError::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+    }
+}

--- a/tests/InlineFragmentTypename/Schema.graphql
+++ b/tests/InlineFragmentTypename/Schema.graphql
@@ -1,0 +1,22 @@
+type Query {
+    ping: String!
+}
+
+type Mutation {
+    addCountry: AddCountryResult!
+}
+
+union AddCountryResult = Country | SupportedCountryError | UnsupportedCountryError
+
+type Country {
+    id: ID!
+    name: String!
+}
+
+type SupportedCountryError {
+    message: String!
+}
+
+type UnsupportedCountryError {
+    code: String!
+}

--- a/tests/InlineFragmentTypename/Test.graphql
+++ b/tests/InlineFragmentTypename/Test.graphql
@@ -1,0 +1,15 @@
+mutation Test {
+    addCountry {
+        ... on Country {
+            id
+            name
+        }
+        ... on SupportedCountryError {
+            __typename
+        }
+        ... on UnsupportedCountryError {
+            __typename
+            code
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Extends the `@api` annotation logic for `__typename` fields to cover inline fragments that only select `__typename`, not just first-level mutation fields. This prevents dead-code analysis tools from incorrectly flagging these fields as unused when they're intentionally queried.

## Key Changes
- **Refactored typename detection logic**: Extracted `selectionSetIsSoleTypename()` method in `SelectionSetPlanner` to centralize the logic for detecting when a selection set contains only an explicitly queried `__typename`
- **Extended @api marking to inline fragments**: Updated `createInlineFragmentClassPlan()` to pass `markTypenameAsApi` parameter based on whether the inline fragment's selection set is a sole `__typename`
- **Updated documentation**: Clarified in `DataClassPlan` that `markTypenameAsApi` now applies to inline fragments and list fields, not just first-level mutation fields
- **Added comprehensive test coverage**: New `InlineFragmentTypenameTest` with test cases validating:
  - Inline fragments with only `__typename` are marked `@api`
  - Inline fragments with `__typename` alongside other fields are NOT marked `@api`
  - Full integration test with GraphQL schema and mutation operations

## Implementation Details
The solution distinguishes between two scenarios:
1. **Sole `__typename` selection** (e.g., `... on SupportedCountryError { __typename }`): Marked `@api` because the caller doesn't read the value back
2. **`__typename` with sibling fields** (e.g., `... on UnsupportedCountryError { __typename code }`): NOT marked `@api` because it's actual data the caller requested

https://claude.ai/code/session_0188h5EK9ZnM6qPm7ATcUyrF