### PR TITLE
Move test classes to non-test namespace

### DIFF
--- a/tests/Planner/NestedFragmentPayloadShapeTest.php
+++ b/tests/Planner/NestedFragmentPayloadShapeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ruudk\GraphQLCodeGenerator\Tests\Planner;
+namespace Ruudk\GraphQLCodeGenerator\Planner;
 
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;

--- a/tests/Planner/SelectionSetPlannerTest.php
+++ b/tests/Planner/SelectionSetPlannerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ruudk\GraphQLCodeGenerator\Tests\Planner;
+namespace Ruudk\GraphQLCodeGenerator\Planner;
 
 use GraphQL\Language\Parser;
 use GraphQL\Utils\BuildSchema;
@@ -13,8 +13,6 @@ use Ruudk\GraphQLCodeGenerator\DirectiveProcessor;
 use Ruudk\GraphQLCodeGenerator\GraphQL\DocumentNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Plan\DataClassPlan;
-use Ruudk\GraphQLCodeGenerator\Planner\PlannerResult;
-use Ruudk\GraphQLCodeGenerator\Planner\SelectionSetPlanner;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
 use Symfony\Component\String\Inflector\EnglishInflector;


### PR DESCRIPTION
This PR relocates test classes from the `Tests` namespace hierarchy to the main `Planner` namespace, making them accessible as regular classes rather than test-only code.

## Summary
Two test files have been moved from the `Ruudk\GraphQLCodeGenerator\Tests\Planner` namespace to `Ruudk\GraphQLCodeGenerator\Planner`, allowing these classes to be used outside of the test suite.

## Key Changes
- `SelectionSetPlannerTest.php`: Namespace changed from `Tests\Planner` to `Planner`
  - Removed unused imports for `PlannerResult` and `SelectionSetPlanner`
- `NestedFragmentPayloadShapeTest.php`: Namespace changed from `Tests\Planner` to `Planner`

## Notes
This change suggests these test classes may serve a dual purpose as both test fixtures and reusable test utilities within the main codebase.

https://claude.ai/code/session_0139EU1SzdoxPnwggtNX7DDP