### PR TITLE
Mark sole __typename selections as @api in all contexts

### DIFF
--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -997,7 +997,7 @@ final class SelectionSetPlanner
             inlineFragmentRequiredFields: $this->inlineFragmentRequiredFields,
             isData: false,
             isFragment: false,
-            markTypenameAsApi: $this->shouldMarkTypenameAsApi($context, $selection, $fieldIsList),
+            markTypenameAsApi: $this->shouldMarkTypenameAsApi($selection),
         );
 
         $this->result->addClass($dataClass);
@@ -1007,30 +1007,14 @@ final class SelectionSetPlanner
      * Selecting nothing but `__typename` means the caller does not actually
      * read the value back — GraphQL just forces at least one field to be
      * selected. The generated `__typename` property is then never used, so we
-     * tag it `@api` to stop dead-code analysis from flagging it. This applies
-     * to:
-     *   - a list field (you must select something to iterate the list), and
-     *   - a first-level "fire and forget" mutation field (only the side
-     *     effect matters).
-     * It must NOT trigger when other fields are selected alongside
-     * `__typename`.
+     * tag it `@api` to stop dead-code analysis from flagging it. This holds
+     * for every sole-`__typename` selection (probing an object's
+     * presence/non-null without reading any data), so it must NOT trigger
+     * only when other fields are selected alongside `__typename`.
      */
-    private function shouldMarkTypenameAsApi(
-        PlanningContext $context,
-        FieldNode $selection,
-        bool $fieldIsList,
-    ) : bool {
-        if ( ! $this->selectionSetIsSoleTypename($selection->selectionSet)) {
-            return false;
-        }
-
-        if ($fieldIsList) {
-            return true;
-        }
-
-        // Root path is the operation type ("mutation"); a first-level field
-        // is therefore exactly "mutation.<fieldName>" (one separator).
-        return str_starts_with($context->path, 'mutation.') && substr_count($context->path, '.') === 1;
+    private function shouldMarkTypenameAsApi(FieldNode $selection) : bool
+    {
+        return $this->selectionSetIsSoleTypename($selection->selectionSet);
     }
 
     /**

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
@@ -8,6 +8,9 @@ namespace Ruudk\GraphQLCodeGenerator\ListTypename\Generated\Query\Test\Data\Fiel
 
 final class Single
 {
+    /**
+     * @api
+     */
     public string $__typename {
         get => $this->__typename ??= $this->data['__typename'];
     }

--- a/tests/ListTypename/ListTypenameTest.php
+++ b/tests/ListTypename/ListTypenameTest.php
@@ -46,15 +46,17 @@ final class ListTypenameTest extends GraphQLTestCase
     }
 
     /**
-     * The rule is list-specific: a sole __typename on a non-list nested
-     * object (and not a first-level mutation field) is not tagged @api.
+     * A sole __typename on a non-list nested object is also selected purely
+     * because GraphQL forces at least one field (probing presence/non-null);
+     * the value is never read, so it is tagged @api too.
      */
-    public function testSoleTypenameOnSingleObjectIsNotApi() : void
+    public function testSoleTypenameOnSingleObjectIsApi() : void
     {
         $docComment = new ReflectionClass(Single::class)
             ->getProperty('__typename')
             ->getDocComment();
 
-        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
     }
 }

--- a/tests/MutationTypename/MutationTypenameTest.php
+++ b/tests/MutationTypename/MutationTypenameTest.php
@@ -47,15 +47,17 @@ final class MutationTypenameTest extends GraphQLTestCase
     }
 
     /**
-     * A __typename selected deeper than the first mutation level is regular
-     * data the caller asked for; it must NOT be tagged @api.
+     * A sole __typename selected deeper than the first mutation level (a
+     * nested object selected purely to probe its presence/non-null) is
+     * never read back either, so it is tagged @api too.
      */
-    public function testTypenameDeeperThanFirstLevelIsNotApi() : void
+    public function testSoleTypenameDeeperThanFirstLevelIsApi() : void
     {
         $docComment = new ReflectionClass(Inner::class)
             ->getProperty('__typename')
             ->getDocComment();
 
-        self::assertStringNotContainsString('@api', $docComment === false ? '' : $docComment);
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
     }
 }

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order;
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Order $order {
+        get => $this->order ??= new Order($this->data['order']);
+    }
+
+    public SupportedCountry $supportedCountry {
+        get => $this->supportedCountry ??= new SupportedCountry($this->data['supportedCountry']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'order': array{
+     *         '__typename': string,
+     *         'fxFee'?: null|array{
+     *             '__typename': string,
+     *         },
+     *         'id'?: string,
+     *     },
+     *     'supportedCountry': array{
+     *         'error': null|array{
+     *             '__typename': string,
+     *         },
+     *         'info': null|array{
+     *             'name': string,
+     *         },
+     *     },
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order\AsMarketPlaceOrderItem;
+
+// This file was automatically generated and should not be edited.
+
+final class Order
+{
+    public ?AsMarketPlaceOrderItem $asMarketPlaceOrderItem {
+        get {
+            if (isset($this->asMarketPlaceOrderItem)) {
+                return $this->asMarketPlaceOrderItem;
+            }
+
+            if ($this->data['__typename'] !== 'MarketPlaceOrderItem') {
+                return $this->asMarketPlaceOrderItem = null;
+            }
+
+            if (! array_key_exists('id', $this->data)) {
+                return $this->asMarketPlaceOrderItem = null;
+            }
+
+            if (! array_key_exists('fxFee', $this->data)) {
+                return $this->asMarketPlaceOrderItem = null;
+            }
+
+            return $this->asMarketPlaceOrderItem = new AsMarketPlaceOrderItem($this->data);
+        }
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asMarketPlaceOrderItem
+     */
+    public bool $isMarketPlaceOrderItem {
+        get => $this->isMarketPlaceOrderItem ??= $this->data['__typename'] === 'MarketPlaceOrderItem';
+    }
+
+    /**
+     * @param array{
+     *     '__typename': string,
+     *     'fxFee'?: null|array{
+     *         '__typename': string,
+     *     },
+     *     'id'?: string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order;
+
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order\AsMarketPlaceOrderItem\FxFee;
+
+// This file was automatically generated and should not be edited.
+
+final class AsMarketPlaceOrderItem
+{
+    public ?FxFee $fxFee {
+        get => $this->fxFee ??= $this->data['fxFee'] !== null ? new FxFee($this->data['fxFee']) : null;
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'MarketPlaceOrderItem',
+     *     'fxFee': null|array{
+     *         '__typename': string,
+     *     },
+     *     'id': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem/FxFee.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem/FxFee.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested;
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order\AsMarketPlaceOrderItem;
 
 // This file was automatically generated and should not be edited.
 
-final class Inner
+final class FxFee
 {
     /**
      * @api

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry\Error;
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry\Info;
+
+// This file was automatically generated and should not be edited.
+
+final class SupportedCountry
+{
+    public ?Error $error {
+        get => $this->error ??= $this->data['error'] !== null ? new Error($this->data['error']) : null;
+    }
+
+    public ?Info $info {
+        get => $this->info ??= $this->data['info'] !== null ? new Info($this->data['info']) : null;
+    }
+
+    /**
+     * @param array{
+     *     'error': null|array{
+     *         '__typename': string,
+     *     },
+     *     'info': null|array{
+     *         'name': string,
+     *     },
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Error.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Error.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Ruudk\GraphQLCodeGenerator\MutationTypename\Generated\Mutation\Test\Data\Nested;
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry;
 
 // This file was automatically generated and should not be edited.
 
-final class Inner
+final class Error
 {
     /**
      * @api

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Info.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Info.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry;
+
+// This file was automatically generated and should not be edited.
+
+final class Info
+{
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'name': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/Error.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/QueryObjectTypename/Generated/Query/Test/TestQuery.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+use Stringable;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test($code: String!, $id: ID!) {
+          supportedCountry(code: $code) {
+            info {
+              name
+            }
+            error {
+              __typename
+            }
+          }
+          order(id: $id) {
+            __typename
+            ... on MarketPlaceOrderItem {
+              id
+              fxFee {
+                __typename
+              }
+            }
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute(
+        Stringable|string $code,
+        Stringable|string $id,
+    ) : Data {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+                'code' => (string) $code,
+                'id' => (string) $id,
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/QueryObjectTypename/QueryObjectTypenameTest.php
+++ b/tests/QueryObjectTypename/QueryObjectTypenameTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\QueryObjectTypename;
+
+use ReflectionClass;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Order\AsMarketPlaceOrderItem\FxFee;
+use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\SupportedCountry\Error;
+
+final class QueryObjectTypenameTest extends GraphQLTestCase
+{
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    /**
+     * `error { __typename }` on a regular (non-list) query object field is
+     * the idiomatic way to probe an object's presence/non-null without
+     * reading any data back, so the generated __typename property is tagged
+     * @api to keep dead-code analysis from flagging it.
+     */
+    public function testSoleTypenameOnQueryObjectFieldIsApi() : void
+    {
+        $docComment = new ReflectionClass(Error::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
+    }
+
+    /**
+     * A sole __typename on an object field nested inside an inline fragment
+     * is generated via the regular field path; it is also never read back,
+     * so it is tagged @api too.
+     */
+    public function testSoleTypenameOnNestedObjectFieldInsideInlineFragmentIsApi() : void
+    {
+        $docComment = new ReflectionClass(FxFee::class)
+            ->getProperty('__typename')
+            ->getDocComment();
+
+        self::assertIsString($docComment);
+        self::assertStringContainsString('@api', $docComment);
+    }
+}

--- a/tests/QueryObjectTypename/Schema.graphql
+++ b/tests/QueryObjectTypename/Schema.graphql
@@ -1,0 +1,34 @@
+type Query {
+    supportedCountry(code: String!): SupportedCountryResult!
+    order(id: ID!): OrderItem!
+}
+
+type SupportedCountryResult {
+    info: SupportedCountryInfo
+    error: SupportedCountryError
+}
+
+type SupportedCountryInfo {
+    name: String!
+}
+
+type SupportedCountryError {
+    code: String!
+    message: String!
+}
+
+union OrderItem = MarketPlaceOrderItem | OtherOrderItem
+
+type MarketPlaceOrderItem {
+    id: ID!
+    fxFee: FxFee
+}
+
+type FxFee {
+    amount: Int!
+    currency: String!
+}
+
+type OtherOrderItem {
+    id: ID!
+}

--- a/tests/QueryObjectTypename/Test.graphql
+++ b/tests/QueryObjectTypename/Test.graphql
@@ -1,0 +1,18 @@
+query Test($code: String!, $id: ID!) {
+    supportedCountry(code: $code) {
+        info {
+            name
+        }
+        error {
+            __typename
+        }
+    }
+    order(id: $id) {
+        ... on MarketPlaceOrderItem {
+            id
+            fxFee {
+                __typename
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Expanded the `@api` annotation for sole `__typename` selections to apply universally, not just to list fields and first-level mutation fields. This recognizes that selecting only `__typename` is an idiomatic pattern for probing an object's presence/non-null without reading actual data back.

## Key Changes
- **Simplified `shouldMarkTypenameAsApi()` logic** in `SelectionSetPlanner.php`: Removed context-specific checks (list detection and mutation-level detection). Now any sole `__typename` selection is marked `@api`, since the value is never actually read by the caller.

- **Updated test expectations** to reflect the new behavior:
  - `ListTypenameTest::testSoleTypenameOnSingleObjectIsApi()`: Changed from expecting no `@api` to expecting `@api` on nested single objects with sole `__typename`
  - `MutationTypenameTest::testSoleTypenameDeeperThanFirstLevelIsApi()`: Changed from expecting no `@api` to expecting `@api` on nested mutation fields with sole `__typename`

- **Added comprehensive test coverage** with new `QueryObjectTypenameTest` that validates:
  - Sole `__typename` on regular query object fields is tagged `@api`
  - Sole `__typename` on nested object fields inside inline fragments is tagged `@api`
  - Includes test schema and generated code examples demonstrating the pattern

## Implementation Details
The change recognizes that sole `__typename` selections serve as a GraphQL idiom for presence/non-null probing without data consumption. This applies consistently across all contexts (queries, mutations, nested fields, inline fragments) rather than being special-cased to specific scenarios. Dead-code analysis tools can now safely ignore these properties since they're marked `@api`.

https://claude.ai/code/session_01LAjUp8CkPDVCjR2WP2Pith