### PR TITLE
Add @api documentation tag to generated input classes

### DIFF
--- a/src/Generator/InputTypeGenerator.php
+++ b/src/Generator/InputTypeGenerator.php
@@ -35,6 +35,8 @@ final class InputTypeGenerator extends AbstractGenerator
 
             yield '';
 
+            yield from $generator->docComment('@api');
+
             if ($this->config->addSymfonyExcludeAttribute) {
                 yield from $generator->dumpAttribute('Symfony\Component\DependencyInjection\Attribute\Exclude');
             }

--- a/tests/Input/Generated/Input/CreateUserInput.php
+++ b/tests/Input/Generated/Input/CreateUserInput.php
@@ -10,6 +10,9 @@ use Stringable;
 
 // This file was automatically generated and should not be edited.
 
+/**
+ * @api
+ */
 final readonly class CreateUserInput implements JsonSerializable
 {
     public function __construct(

--- a/tests/OneOfDirective/Generated/Input/UserByInput.php
+++ b/tests/OneOfDirective/Generated/Input/UserByInput.php
@@ -10,6 +10,9 @@ use Stringable;
 
 // This file was automatically generated and should not be edited.
 
+/**
+ * @api
+ */
 final readonly class UserByInput implements JsonSerializable
 {
     private function __construct(


### PR DESCRIPTION
## Summary
This change adds the `@api` documentation tag to all generated input type classes to mark them as part of the public API surface.

## Key Changes
- Modified `InputTypeGenerator.php` to emit a `@api` doc comment before class declarations
- The doc comment is added to all generated input classes, making them explicitly marked as public API
- Updated generated test fixtures to reflect the new doc comment output

## Implementation Details
The `@api` tag is inserted in the code generation pipeline by yielding a doc comment from the generator before any other class-level attributes. This ensures consistent documentation across all generated input type classes and helps tools and developers identify these classes as part of the stable public API.

https://claude.ai/code/session_012AytSm5RmBRNbm5B81SZvS