### PR TITLE
Skip no-op array_map when collection value needs no transformation

### DIFF
--- a/src/TypeInitializer/CollectionTypeInitializer.php
+++ b/src/TypeInitializer/CollectionTypeInitializer.php
@@ -32,9 +32,17 @@ final class CollectionTypeInitializer implements TypeInitializer
         string $variable,
         DelegatingTypeInitializer $delegator,
     ) : Generator {
+        $inner = $delegator($type->getCollectionValueType(), $generator, '$item');
+
+        if ($inner === '$item') {
+            yield $variable;
+
+            return;
+        }
+
         yield from $generator->wrap(
             'array_map(fn($item) => ',
-            $delegator($type->getCollectionValueType(), $generator, '$item'),
+            $inner,
             sprintf(', %s)', $variable),
         );
     }

--- a/src/TypeInitializer/IndexByCollectionTypeInitializer.php
+++ b/src/TypeInitializer/IndexByCollectionTypeInitializer.php
@@ -80,9 +80,17 @@ final class IndexByCollectionTypeInitializer implements TypeInitializer
                 );
             }
 
+            $inner = $delegator($type->value, $generator, '$item');
+
+            if ($inner === '$item') {
+                yield sprintf('%s,', $variable);
+
+                return;
+            }
+
             yield from $generator->wrap(
                 'array_map(fn($item) => ',
-                $delegator($type->value, $generator, '$item'),
+                $inner,
                 sprintf(', %s),', $variable),
             );
         });

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
@@ -15,7 +15,7 @@ final class Project
      * @var list<string>
      */
     public array $contributorIds {
-        get => $this->contributorIds ??= array_map(fn($item) => $item, $this->data['contributorIds']);
+        get => $this->contributorIds ??= $this->data['contributorIds'];
     }
 
     /**


### PR DESCRIPTION
`CollectionTypeInitializer` always wrapped the collection value in `array_map(fn($item) => …, $var)`, even when the inner type has no registered initializer. In that case `DelegatingTypeInitializer` returns the variable string unchanged, so the generated code became `array_map(fn($item) => $item, $this->data['…'])` — a pure no-op.

This is not just wasted work: it sits inside a lazy property hook (`get => $this->prop ??= …`), so every scalar-typed list/array field rebuilds the entire array element-by-element on first access to produce an identical array.

Detect the identity case (delegator returns the `$item` string unchanged) and emit the array as-is instead. The same latent no-op is guarded in `IndexByCollectionTypeInitializer`'s single-field arm.

The regenerated `HooksWithListReturn` golden fixture pins the fixed output; reverting the fix makes `testGenerate` fail with the no-op `array_map` reappearing.
