### PR TITLE
Inject type and import for GeneratedGraphQLFragment

### DIFF
--- a/src/PHP/Visitor/FragmentFinder.php
+++ b/src/PHP/Visitor/FragmentFinder.php
@@ -61,6 +61,14 @@ final class FragmentFinder extends NodeVisitorAbstract
                         continue;
                     }
 
+                    if ($node->name->toString() === '__construct') {
+                        throw new InvalidArgumentException(sprintf(
+                            'The #[GeneratedGraphQLFragment] attribute cannot be used on constructor parameters. Found on "%s::__construct::$%s". Use it on a non-constructor method parameter instead.',
+                            $this->className,
+                            $param->var->name,
+                        ));
+                    }
+
                     if (count($attr->args) !== 1) {
                         continue;
                     }

--- a/src/PHP/Visitor/OperationInjector.php
+++ b/src/PHP/Visitor/OperationInjector.php
@@ -44,7 +44,21 @@ final class OperationInjector extends NodeVisitorAbstract
                 continue;
             }
 
-            $param->type = new Name(new Name($this->operations[$node->name->toString()][$param->var->name])->getLast());
+            // A collection contract (`array`/`iterable $items` with a
+            // `@param list<Fragment>` docblock) already states its cardinality;
+            // only the import needs maintaining, so leave the declared type and
+            // let UseStatementInserter add the class.
+            if ($param->type instanceof Node\Identifier
+                && in_array(strtolower($param->type->name), ['array', 'iterable'], true)) {
+                continue;
+            }
+
+            $name = new Name(new Name($this->operations[$node->name->toString()][$param->var->name])->getLast());
+
+            // Preserve an explicitly nullable single contract (`?Fragment $x`).
+            $param->type = $param->type instanceof Node\NullableType
+                ? new Node\NullableType($name)
+                : $name;
 
             $changed = true;
         }

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -376,6 +376,11 @@ final class Planner
 
                             $usedTypesCollector->analyze($document);
 
+                            $operationsToInject[$file->getPathname()][$method][$property] = $this->fullyQualified(
+                                'Fragment',
+                                $name . $shortHash,
+                                $name,
+                            );
                             $operations[$file->getPathname()][] = DocumentNodeWithSource::create(
                                 $document,
                                 new InlineFragmentSource(

--- a/tests/PHP/Visitor/FragmentFinderTest.php
+++ b/tests/PHP/Visitor/FragmentFinderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use InvalidArgumentException;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+final class FragmentFinderTest extends TestCase
+{
+    public function testFindsFragmentOnRegularMethod() : void
+    {
+        $finder = $this->collect(
+            <<<'PHP'
+                <?php
+                namespace App;
+                use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLFragment;
+                final class UserMapper {
+                    private const string FRAGMENT = 'fragment UserName on User { id }';
+                    public function mapMany(
+                        #[GeneratedGraphQLFragment(self::FRAGMENT)]
+                        array $users,
+                    ) : void {}
+                }
+                PHP,
+        );
+
+        self::assertSame(
+            [
+                'App\UserMapper' => [
+                    'mapMany' => [
+                        'users' => 'fragment UserName on User { id }',
+                    ],
+                ],
+            ],
+            $finder->fragments,
+        );
+    }
+
+    public function testThrowsWhenUsedOnConstructorParameter() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The #[GeneratedGraphQLFragment] attribute cannot be used on constructor parameters. Found on "App\UserMapper::__construct::$data". Use it on a non-constructor method parameter instead.');
+
+        $this->collect(
+            <<<'PHP'
+                <?php
+                namespace App;
+                use Ruudk\GraphQLCodeGenerator\Attribute\GeneratedGraphQLFragment;
+                final class UserMapper {
+                    private const string FRAGMENT = 'fragment UserName on User { id }';
+                    public function __construct(
+                        #[GeneratedGraphQLFragment(self::FRAGMENT)]
+                        private object $data,
+                    ) {}
+                }
+                PHP,
+        );
+    }
+
+    private function collect(string $code) : FragmentFinder
+    {
+        $stmts = new ParserFactory()->createForNewestSupportedVersion()->parse($code);
+        self::assertNotNull($stmts);
+
+        $classConstants = new ClassConstantFinder();
+        $stmts = new NodeTraverser(new NameResolver(), $classConstants)->traverse($stmts);
+
+        $finder = new FragmentFinder($classConstants->constants);
+        new NodeTraverser($finder)->traverse($stmts);
+
+        return $finder;
+    }
+}

--- a/tests/PHP/Visitor/OperationInjectorTest.php
+++ b/tests/PHP/Visitor/OperationInjectorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\PHP\Visitor;
+
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
+
+final class OperationInjectorTest extends TestCase
+{
+    public function testReplacesSingleObjectContract() : void
+    {
+        $printed = $this->inject(
+            'consume',
+            'data',
+            'App\Generated\Fragment\UserName56995d\UserName',
+            'public function consume(object $data) : void {}',
+        );
+
+        self::assertStringContainsString('function consume(UserName $data)', $printed);
+    }
+
+    public function testPreservesNullableSingleContract() : void
+    {
+        $printed = $this->inject(
+            'consume',
+            'user',
+            'App\Generated\Fragment\UserName56995d\UserName',
+            'public function consume(?UserName $user) : void {}',
+        );
+
+        self::assertStringContainsString('function consume(?UserName $user)', $printed);
+    }
+
+    public function testLeavesCollectionTypeForDocblock() : void
+    {
+        $printed = $this->inject(
+            'mapMany',
+            'users',
+            'App\Generated\Fragment\UserName56995d\UserName',
+            'public function mapMany(array $users) : void {}',
+        );
+
+        self::assertStringContainsString('function mapMany(array $users)', $printed);
+    }
+
+    private function inject(string $method, string $param, string $fqcn, string $methodCode) : string
+    {
+        $code = sprintf('<?php class C { %s }', $methodCode);
+
+        $stmts = new ParserFactory()->createForNewestSupportedVersion()->parse($code);
+        self::assertNotNull($stmts);
+
+        $stmts = new NodeTraverser(
+            new OperationInjector([
+                $method => [
+                    $param => $fqcn,
+                ],
+            ]),
+        )->traverse($stmts);
+
+        return new Standard()->prettyPrintFile($stmts);
+    }
+}


### PR DESCRIPTION
`#[GeneratedGraphQLFragment]` only emitted the fragment class; unlike `#[GeneratedGraphQLClient]` it never rewrote the tagged parameter's type or maintained its import, so consumers had to hand-write the fully-qualified class and `use` line. It also silently did nothing when placed on a constructor parameter.

Register each inline fragment in `operationsToInject` so it flows through the same `OperationInjector` + `UseStatementInserter` pipeline as operations. The author still expresses cardinality via the declared type, so `OperationInjector` is now cardinality-aware: a single contract (`object`/`?Fragment`) has its type rewritten to the generated class (nullability preserved), while a collection (`array`/`iterable` with a `@param list<Fragment>` docblock) keeps its declared type and only gets the import maintained.

Constructor parameters are not a valid declaration site for a data contract, so `FragmentFinder` now throws a clear error naming the offending `Class::__construct::$param` instead of silently ignoring it.
