### PR TITLE
Render loaders shape as multi-line PHPDoc

### DIFF
--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -174,12 +174,16 @@ final class DataClassGenerator extends AbstractGenerator
                 '%s: %s<%s, %s>',
                 $name,
                 $hookLoader,
-                TypeDumper::dump($this->resolveHookInputTuple($name, $plansByFqcn), $generator->import(...)),
-                TypeDumper::dump($this->config->hooks[$name]->returnType, $generator->import(...)),
+                TypeDumper::dump($this->resolveHookInputTuple($name, $plansByFqcn), $generator->import(...), 1),
+                TypeDumper::dump($this->config->hooks[$name]->returnType, $generator->import(...), 1),
             );
         }
 
-        return sprintf('array{%s}', implode(', ', $entries));
+        if ($entries === []) {
+            return 'array{}';
+        }
+
+        return sprintf("array{\n    %s,\n}", implode(",\n    ", $entries));
     }
 
     /**

--- a/tests/HooksBatched/Generated/Query/Test/Data.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data.php
@@ -30,7 +30,11 @@ final class Data
     public readonly array $errors;
 
     /**
-     * @var array{findOrgPlan: HookLoader<array{string}, OrgPlan>, computeAccess: HookLoader<array{string, string}, Access>, findUserById: HookLoader<array{string}, null|User>}
+     * @var array{
+     *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
+     *     computeAccess: HookLoader<array{string, string}, Access>,
+     *     findUserById: HookLoader<array{string}, null|User>,
+     * }
      */
     private readonly array $loaders;
 

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
@@ -44,7 +44,11 @@ final class Organization
      *         'reviewerId': string,
      *     }>,
      * } $data
-     * @param array{findOrgPlan: HookLoader<array{string}, OrgPlan>, computeAccess: HookLoader<array{string, string}, Access>, findUserById: HookLoader<array{string}, null|User>} $loaders
+     * @param array{
+     *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
+     *     computeAccess: HookLoader<array{string, string}, Access>,
+     *     findUserById: HookLoader<array{string}, null|User>,
+     * } $loaders
      */
     public function __construct(
         private readonly array $data,

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
@@ -43,7 +43,10 @@ final class Repository
      *     'ownerId': string,
      *     'reviewerId': string,
      * } $data
-     * @param array{computeAccess: HookLoader<array{string, string}, Access>, findUserById: HookLoader<array{string}, null|User>} $loaders
+     * @param array{
+     *     computeAccess: HookLoader<array{string, string}, Access>,
+     *     findUserById: HookLoader<array{string}, null|User>,
+     * } $loaders
      */
     public function __construct(
         private readonly array $data,


### PR DESCRIPTION
The `array{...}` shape for `$loaders` was emitted on a single line via `implode(', ', $entries)`, producing a long unwieldy `@param`/`@var` that was inconsistent with how `TypeDumper` formats `ArrayShapeType` (one entry per line with a trailing comma). Emit the same multi-line layout so generated docblocks stay readable as the batched-hook list grows.
