### PR TITLE
PHPStan 2.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,13 +335,17 @@ final class Data
      *             'merged'?: bool,
      *             'number'?: int,
      *             'title'?: string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(
@@ -763,22 +767,29 @@ final class Data
      *             'node': array{
      *                 'id': int,
      *                 'name': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
      *     'issues': list<array{
      *         'id': int,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'projects': list<array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(
@@ -859,7 +870,9 @@ final class Viewer
      *     'project': null|array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(
@@ -1075,6 +1088,7 @@ final class ProjectView
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(
@@ -1108,6 +1122,7 @@ final class Project
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/filesystem": "^8.0",
         "symfony/finder": "^8.0",
         "symfony/string": "^8.0",
-        "symfony/type-info": "^8.0",
+        "symfony/type-info": "^8.0.6",
         "webmozart/assert": "^2.0",
         "webonyx/graphql-php": "^15.24.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -113,11 +113,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.50",
+            "version": "2.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
-                "reference": "d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
+                "reference": "b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
                 "shasum": ""
             },
             "require": {
@@ -139,6 +139,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -162,7 +173,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-17T13:10:32+00:00"
+            "time": "2026-05-28T08:22:43+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "635f6b064323c37a2d85ea8f1f832131",
+    "content-hash": "29bb91f2a1d88dbbdb6e6382d66da1e4",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -1178,16 +1178,16 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "622d81551770029d44d16be68969712eb47892f1"
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/622d81551770029d44d16be68969712eb47892f1",
-                "reference": "622d81551770029d44d16be68969712eb47892f1",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866",
                 "shasum": ""
             },
             "require": {
@@ -1236,7 +1236,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v8.0.8"
+                "source": "https://github.com/symfony/type-info/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -1256,7 +1256,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/examples/Generated/Fragment/PullRequestInfo.php
+++ b/examples/Generated/Fragment/PullRequestInfo.php
@@ -32,6 +32,7 @@ final class PullRequestInfo
      *     'merged': bool,
      *     'number': int,
      *     'title': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/examples/Generated/Query/Search/Data.php
+++ b/examples/Generated/Query/Search/Data.php
@@ -41,13 +41,17 @@ final class Data
      *             'merged'?: bool,
      *             'number'?: int,
      *             'title'?: string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection.php
@@ -36,7 +36,9 @@ final class SearchResultItemConnection
      *         'merged'?: bool,
      *         'number'?: int,
      *         'title'?: string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
@@ -95,6 +95,7 @@ final class Node
      *     'merged'?: bool,
      *     'number'?: int,
      *     'title'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node/AsIssue.php
@@ -27,6 +27,7 @@ final class AsIssue
      *     '__typename': 'Issue',
      *     'number': int,
      *     'title': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/examples/Generated/Query/Search/Error.php
+++ b/examples/Generated/Query/Search/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/examples/Generated/Query/Viewer/Data.php
+++ b/examples/Generated/Query/Viewer/Data.php
@@ -30,12 +30,15 @@ final class Data
      * @param array{
      *     'viewer': array{
      *         'login': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/examples/Generated/Query/Viewer/Data/Viewer.php
+++ b/examples/Generated/Query/Viewer/Data/Viewer.php
@@ -20,6 +20,7 @@ final class Viewer
     /**
      * @param array{
      *     'login': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/examples/Generated/Query/Viewer/Error.php
+++ b/examples/Generated/Query/Viewer/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/examples/GitHubClient.php
+++ b/examples/GitHubClient.php
@@ -48,7 +48,7 @@ final readonly class GitHubClient
 
         Assert::same(200, $response->getStatusCode(), 'GraphQL server responded with a %2$s status code.');
 
-        $data = json_decode((string) $response->getBody(), true, JSON_THROW_ON_ERROR);
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         Assert::isArray($data, 'GraphQL server did not return an array.');
 

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -105,6 +105,6 @@ abstract class AbstractGenerator
             $shape[$name] = Type::object($this->config->hooks[$name]->class);
         }
 
-        return Type::arrayShape($shape);
+        return Type::arrayShape($shape, sealed: false);
     }
 }

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -179,9 +179,11 @@ final class DataClassGenerator extends AbstractGenerator
             );
         }
 
-        if ($entries === []) {
-            return 'array{}';
-        }
+        // Unsealed: nested classes receive `$this->loaders` from the Data class,
+        // which holds every batched hook in the operation, not just the subset a
+        // single nested class consumes. Extras are typed wide; HookLoader's
+        // covariant template params let any specific instantiation fit here.
+        $entries[] = sprintf('...<string, %s<array<int, mixed>, mixed>>', $hookLoader);
 
         return sprintf("array{\n    %s,\n}", implode(",\n    ", $entries));
     }
@@ -552,7 +554,7 @@ final class DataClassGenerator extends AbstractGenerator
             if (isset($shape['__typename'])) {
                 // Use a StringLiteralType for the __typename
                 $shape['__typename'] = new StringLiteralType($possibleTypes[0]);
-                $payloadShape = SymfonyType::arrayShape($shape);
+                $payloadShape = SymfonyType::arrayShape($shape, sealed: false);
             }
         }
 
@@ -1119,7 +1121,7 @@ final class DataClassGenerator extends AbstractGenerator
                                         'type' => SymfonyType::string(),
                                         'optional' => true,
                                     ],
-                                ])), $generator->import(...)),
+                                ], sealed: false)), $generator->import(...)),
                             );
                         }
 

--- a/src/Generator/ErrorClassGenerator.php
+++ b/src/Generator/ErrorClassGenerator.php
@@ -36,7 +36,7 @@ final class ErrorClassGenerator extends AbstractGenerator
                         'type' => Type::string(),
                         'optional' => true,
                     ],
-                ]), $generator->import(...))));
+                ], sealed: false), $generator->import(...))));
                 yield 'public function __construct(array $error)';
                 yield '{';
                 yield $generator->indent(function () {

--- a/src/Generator/HookLoaderGenerator.php
+++ b/src/Generator/HookLoaderGenerator.php
@@ -32,8 +32,8 @@ final class HookLoaderGenerator extends AbstractGenerator
                 yield 'instance.';
                 yield '';
                 yield '@internal';
-                yield '@template TInput';
-                yield '@template TResult';
+                yield '@template-covariant TInput';
+                yield '@template-covariant TResult';
             });
             yield 'final class HookLoader';
             yield '{';

--- a/src/Planner/FieldCollection.php
+++ b/src/Planner/FieldCollection.php
@@ -30,6 +30,6 @@ final class FieldCollection
 
     public function toArrayShape() : SymfonyType
     {
-        return SymfonyType::arrayShape($this->fields);
+        return SymfonyType::arrayShape($this->fields, sealed: false);
     }
 }

--- a/src/Planner/PayloadShape.php
+++ b/src/Planner/PayloadShape.php
@@ -93,7 +93,7 @@ final class PayloadShape
                         $existingType->getShape(),
                         $type->getShape(),
                     );
-                    $this->replaceType($key, SymfonyType::arrayShape($mergedElements));
+                    $this->replaceType($key, SymfonyType::arrayShape($mergedElements, sealed: false));
 
                     continue;
                 }
@@ -108,7 +108,7 @@ final class PayloadShape
                             $existingInner->getShape(),
                             $newInner->getShape(),
                         );
-                        $this->replaceType($key, SymfonyType::list(SymfonyType::arrayShape($mergedElements)));
+                        $this->replaceType($key, SymfonyType::list(SymfonyType::arrayShape($mergedElements, sealed: false)));
                     }
                 }
 
@@ -128,6 +128,6 @@ final class PayloadShape
 
     public function toArrayShape() : SymfonyType
     {
-        return SymfonyType::arrayShape($this->shape);
+        return SymfonyType::arrayShape($this->shape, sealed: false);
     }
 }

--- a/src/Type/TypeDumper.php
+++ b/src/Type/TypeDumper.php
@@ -39,6 +39,21 @@ final class TypeDumper
                 $items[] = sprintf('%s: %s', $itemKey, self::dump($itemType, $importer, $indentation + 1));
             }
 
+            if ( ! $type->isSealed()) {
+                $extraKey = $type->getExtraKeyType();
+                $extraValue = $type->getExtraValueType();
+
+                // Always emit `...<K, V>` rather than the bare `...` short form:
+                // PHPStan's `missingType.iterableValue` rule at level 6+ rejects
+                // the implicit `array-key, mixed` extras, treating them as a
+                // missing iterable value type.
+                $items[] = sprintf(
+                    '...<%s, %s>',
+                    self::dump($extraKey ?? Type::arrayKey(), $importer, $indentation + 1),
+                    self::dump($extraValue ?? Type::mixed(), $importer, $indentation + 1),
+                );
+            }
+
             if ($items === []) {
                 return 'array{}';
             }

--- a/tests/ConnectionNames/Generated/Query/Test/Data.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data.php
@@ -33,26 +33,33 @@ final class Data
      *                 'id': string,
      *                 'name': string,
      *                 'status': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
      *         'pageInfo': array{
      *             'endCursor': null|string,
      *             'hasNextPage': bool,
      *             'hasPreviousPage': bool,
      *             'startCursor': null|string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
      *     'viewer': null|array{
      *         'createdAt': scalar,
      *         'id': string,
      *         'name': string,
      *         'role': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection.php
@@ -30,14 +30,18 @@ final class ProjectConnection
      *             'id': string,
      *             'name': string,
      *             'status': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
      *     'pageInfo': array{
      *         'endCursor': null|string,
      *         'hasNextPage': bool,
      *         'hasPreviousPage': bool,
      *         'startCursor': null|string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/PageInfo.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/PageInfo.php
@@ -30,6 +30,7 @@ final class PageInfo
      *     'hasNextPage': bool,
      *     'hasPreviousPage': bool,
      *     'startCursor': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/ProjectEdge.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/ProjectEdge.php
@@ -25,7 +25,9 @@ final class ProjectEdge
      *         'id': string,
      *         'name': string,
      *         'status': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/ProjectEdge/Project.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data/ProjectConnection/ProjectEdge/Project.php
@@ -27,6 +27,7 @@ final class Project
      *     'id': string,
      *     'name': string,
      *     'status': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Data/Viewer.php
@@ -32,6 +32,7 @@ final class Viewer
      *     'id': string,
      *     'name': string,
      *     'role': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ConnectionNames/Generated/Query/Test/Error.php
+++ b/tests/ConnectionNames/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/DumpDefinitions/Generated/Query/Test/Data.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/Data.php
@@ -37,13 +37,17 @@ final class Data
      *         'projects': list<array{
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/DumpDefinitions/Generated/Query/Test/Data/Viewer.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/Data/Viewer.php
@@ -36,7 +36,9 @@ final class Viewer
      *     'projects': list<array{
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/DumpDefinitions/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/Data/Viewer/Project.php
@@ -26,6 +26,7 @@ final class Project
      * @param array{
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/DumpDefinitions/Generated/Query/Test/Error.php
+++ b/tests/DumpDefinitions/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/DumpOrThrows/Generated/Query/Test/Data.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/Data.php
@@ -26,13 +26,17 @@ final class Data
      *         'projects': list<array{
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/DumpOrThrows/Generated/Query/Test/Data/Viewer.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/Data/Viewer.php
@@ -27,7 +27,9 @@ final class Viewer
      *     'projects': list<array{
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/DumpOrThrows/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/Data/Viewer/Project.php
@@ -29,6 +29,7 @@ final class Project
      * @param array{
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/DumpOrThrows/Generated/Query/Test/Error.php
+++ b/tests/DumpOrThrows/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Enum/Generated/Query/Test/Data.php
+++ b/tests/Enum/Generated/Query/Test/Data.php
@@ -39,11 +39,13 @@ final class Data
      *     'otherRole': null|string,
      *     'priority': null|string,
      *     'role': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Enum/Generated/Query/Test/Error.php
+++ b/tests/Enum/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/EnumDumpIsMethods/Generated/Query/Test/Data.php
+++ b/tests/EnumDumpIsMethods/Generated/Query/Test/Data.php
@@ -39,11 +39,13 @@ final class Data
      *     'otherRole': null|string,
      *     'priority': null|string,
      *     'role': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/EnumDumpIsMethods/Generated/Query/Test/Error.php
+++ b/tests/EnumDumpIsMethods/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/ExplicitTypename/Generated/Fragment/UserDetails.php
+++ b/tests/ExplicitTypename/Generated/Fragment/UserDetails.php
@@ -15,6 +15,7 @@ final class UserDetails
     /**
      * @param array{
      *     'login': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ExplicitTypename/Generated/Query/Test/Data.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data.php
@@ -26,12 +26,15 @@ final class Data
      *         'login'?: string,
      *         'name': string,
      *         'url'?: string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
@@ -81,6 +81,7 @@ final class Viewer
      *     'login'?: string,
      *     'name': string,
      *     'url'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer/AsApplication.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer/AsApplication.php
@@ -25,6 +25,7 @@ final class AsApplication
      *     '__typename': 'Application',
      *     'name': string,
      *     'url': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ExplicitTypename/Generated/Query/Test/Error.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow.php
@@ -29,10 +29,15 @@ final class AdminViewSystemShowWorkflow
      *                 'id': scalar,
      *                 'transfer': array{
      *                     'metadata': scalar,
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             }>,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction.php
@@ -26,9 +26,13 @@ final class Transaction
      *             'id': scalar,
      *             'transfer': array{
      *                 'metadata': scalar,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction/Transfer.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction/Transfer.php
@@ -34,8 +34,11 @@ final class Transfer
      *         'id': scalar,
      *         'transfer': array{
      *             'metadata': scalar,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction/Transfer/TransferReversal.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemShowWorkflow/Transaction/Transfer/TransferReversal.php
@@ -18,7 +18,9 @@ final class TransferReversal
      * @param array{
      *     'transfer': array{
      *         'metadata': scalar,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferReversalRow.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferReversalRow.php
@@ -18,7 +18,9 @@ final class AdminViewSystemTransferReversalRow
      * @param array{
      *     'transfer': array{
      *         'metadata': scalar,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferReversalRow/Transfer.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferReversalRow/Transfer.php
@@ -15,6 +15,7 @@ final class Transfer
     /**
      * @param array{
      *     'metadata': scalar,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferRow.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferRow.php
@@ -21,7 +21,9 @@ final class AdminViewSystemTransferRow
      *     'canBeCollected': bool,
      *     'transferReversals': list<array{
      *         'id': scalar,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferState.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferState.php
@@ -21,7 +21,9 @@ final class AdminViewSystemTransferState
      * @param array{
      *     'transferReversals': list<array{
      *         'id': scalar,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferState/TransferReversal.php
+++ b/tests/FragmentIsolation/Generated/Fragment/AdminViewSystemTransferState/TransferReversal.php
@@ -15,6 +15,7 @@ final class TransferReversal
     /**
      * @param array{
      *     'id': scalar,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data.php
@@ -28,22 +28,30 @@ final class Data
      *                 'canBeCollected': bool,
      *                 'customer': array{
      *                     'id': scalar,
+     *                     ...<int|string, mixed>,
      *                 },
      *                 'id': scalar,
      *                 'transferReversals': list<array{
      *                     'id': scalar,
      *                     'transfer': array{
      *                         'metadata': scalar,
+     *                         ...<int|string, mixed>,
      *                     },
+     *                     ...<int|string, mixed>,
      *                 }>,
+     *                 ...<int|string, mixed>,
      *             }>,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow.php
@@ -27,16 +27,22 @@ final class Workflow
      *             'canBeCollected': bool,
      *             'customer': array{
      *                 'id': scalar,
+     *                 ...<int|string, mixed>,
      *             },
      *             'id': scalar,
      *             'transferReversals': list<array{
      *                 'id': scalar,
      *                 'transfer': array{
      *                     'metadata': scalar,
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             }>,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction.php
@@ -22,9 +22,12 @@ final class Transaction
      *     'transfers': list<array{
      *         'customer': array{
      *             'id': scalar,
+     *             ...<int|string, mixed>,
      *         },
      *         'id': scalar,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction/Transfer.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction/Transfer.php
@@ -22,8 +22,10 @@ final class Transfer
      * @param array{
      *     'customer': array{
      *         'id': scalar,
+     *         ...<int|string, mixed>,
      *     },
      *     'id': scalar,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction/Transfer/Customer.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Data/Workflow/Transaction/Transfer/Customer.php
@@ -15,6 +15,7 @@ final class Customer
     /**
      * @param array{
      *     'id': scalar,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Error.php
+++ b/tests/FragmentIsolation/Generated/Query/GetWorkflowForAdmin/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails.php
@@ -37,6 +37,7 @@ final class TransferDetails
      *     'total': array{
      *         'amount': string,
      *         'currency': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'transferReversals': list<array{
      *         'createdAt': string,
@@ -47,7 +48,9 @@ final class TransferDetails
      *             'total': array{
      *                 'amount': string,
      *                 'currency': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
      *         'returnMethod': null|string,
      *         'returnedAt': null|string,
@@ -55,8 +58,11 @@ final class TransferDetails
      *         'total': array{
      *             'amount': string,
      *             'currency': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails/Total.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails/Total.php
@@ -20,6 +20,7 @@ final class Total
      * @param array{
      *     'amount': string,
      *     'currency': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails/TransferReversal.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferDetails/TransferReversal.php
@@ -24,7 +24,9 @@ final class TransferReversal
      *         'total': array{
      *             'amount': string,
      *             'currency': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
      *     'returnMethod': null|string,
      *     'returnedAt': null|string,
@@ -32,7 +34,9 @@ final class TransferReversal
      *     'total': array{
      *         'amount': string,
      *         'currency': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails.php
@@ -52,7 +52,9 @@ final class TransferReversalDetails
      *         'total': array{
      *             'amount': string,
      *             'currency': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
      *     'returnMethod': null|string,
      *     'returnedAt': null|string,
@@ -60,7 +62,9 @@ final class TransferReversalDetails
      *     'total': array{
      *         'amount': string,
      *         'currency': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Resolution.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Resolution.php
@@ -29,7 +29,9 @@ final class Resolution
      *     'total': array{
      *         'amount': string,
      *         'currency': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Resolution/Total.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Resolution/Total.php
@@ -20,6 +20,7 @@ final class Total
      * @param array{
      *     'amount': string,
      *     'currency': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Total.php
+++ b/tests/FragmentSpreadBug/Generated/Fragment/TransferReversalDetails/Total.php
@@ -20,6 +20,7 @@ final class Total
      * @param array{
      *     'amount': string,
      *     'currency': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data.php
@@ -31,6 +31,7 @@ final class Data
      *             'total': array{
      *                 'amount': string,
      *                 'currency': string,
+     *                 ...<int|string, mixed>,
      *             },
      *             'transferReversals': list<array{
      *                 'createdAt': string,
@@ -41,7 +42,9 @@ final class Data
      *                     'total': array{
      *                         'amount': string,
      *                         'currency': string,
+     *                         ...<int|string, mixed>,
      *                     },
+     *                     ...<int|string, mixed>,
      *                 }>,
      *                 'returnMethod': null|string,
      *                 'returnedAt': null|string,
@@ -49,15 +52,21 @@ final class Data
      *                 'total': array{
      *                     'amount': string,
      *                     'currency': string,
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             }>,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction.php
@@ -36,6 +36,7 @@ final class Transaction
      *         'total': array{
      *             'amount': string,
      *             'currency': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'transferReversals': list<array{
      *             'createdAt': string,
@@ -46,7 +47,9 @@ final class Transaction
      *                 'total': array{
      *                     'amount': string,
      *                     'currency': string,
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             }>,
      *             'returnMethod': null|string,
      *             'returnedAt': null|string,
@@ -54,9 +57,13 @@ final class Transaction
      *             'total': array{
      *                 'amount': string,
      *                 'currency': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction/Transfer.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction/Transfer.php
@@ -38,6 +38,7 @@ final class Transfer
      *     'total': array{
      *         'amount': string,
      *         'currency': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'transferReversals': list<array{
      *         'createdAt': string,
@@ -48,7 +49,9 @@ final class Transfer
      *             'total': array{
      *                 'amount': string,
      *                 'currency': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
      *         'returnMethod': null|string,
      *         'returnedAt': null|string,
@@ -56,8 +59,11 @@ final class Transfer
      *         'total': array{
      *             'amount': string,
      *             'currency': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction/Transfer/TransferReversal.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Data/Transaction/Transfer/TransferReversal.php
@@ -20,6 +20,7 @@ final class TransferReversal
      * @param array{
      *     'id': string,
      *     'state': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Error.php
+++ b/tests/FragmentSpreadBug/Generated/Query/GetTransactionDetails/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Fragments/Generated/Fragment/ApplicationDetails.php
+++ b/tests/Fragments/Generated/Fragment/ApplicationDetails.php
@@ -15,6 +15,7 @@ final class ApplicationDetails
     /**
      * @param array{
      *     'url': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Fragment/ProjectStateView.php
+++ b/tests/Fragments/Generated/Fragment/ProjectStateView.php
@@ -15,6 +15,7 @@ final class ProjectStateView
     /**
      * @param array{
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Fragment/ProjectView.php
+++ b/tests/Fragments/Generated/Fragment/ProjectView.php
@@ -25,6 +25,7 @@ final class ProjectView
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Fragment/UserDetails.php
+++ b/tests/Fragments/Generated/Fragment/UserDetails.php
@@ -15,6 +15,7 @@ final class UserDetails
     /**
      * @param array{
      *     'login': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Fragment/ViewerName.php
+++ b/tests/Fragments/Generated/Fragment/ViewerName.php
@@ -15,6 +15,7 @@ final class ViewerName
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Query/Test/Data.php
+++ b/tests/Fragments/Generated/Query/Test/Data.php
@@ -33,18 +33,22 @@ final class Data
      *         'description': null|string,
      *         'name': string,
      *         'state': null|string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'viewer': array{
      *         '__typename': string,
      *         'login'?: string,
      *         'name': string,
      *         'url'?: string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Fragments/Generated/Query/Test/Data/Project.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Project.php
@@ -19,6 +19,7 @@ final class Project
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Viewer.php
@@ -82,6 +82,7 @@ final class Viewer
      *     'login'?: string,
      *     'name': string,
      *     'url'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Query/Test/Error.php
+++ b/tests/Fragments/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Hooks/Generated/Query/Test/Data.php
+++ b/tests/Hooks/Generated/Query/Test/Data.php
@@ -27,19 +27,25 @@ final class Data
      *         'projects': list<array{
      *             'creator': array{
      *                 'id': string,
+     *                 ...<int|string, mixed>,
      *             },
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer.php
@@ -28,13 +28,17 @@ final class Viewer
      *     'projects': list<array{
      *         'creator': array{
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer/Project.php
@@ -32,12 +32,15 @@ final class Project
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/Hooks/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/Hooks/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -15,6 +15,7 @@ final class Creator
     /**
      * @param array{
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Hooks/Generated/Query/Test/Error.php
+++ b/tests/Hooks/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Hooks/Generated/Query/Test/TestQuery.php
+++ b/tests/Hooks/Generated/Query/Test/TestQuery.php
@@ -30,6 +30,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksBatched/Generated/HookLoader.php
+++ b/tests/HooksBatched/Generated/HookLoader.php
@@ -18,8 +18,8 @@ use WeakMap;
  * instance.
  * 
  * @internal
- * @template TInput
- * @template TResult
+ * @template-covariant TInput
+ * @template-covariant TResult
  */
 final class HookLoader
 {

--- a/tests/HooksBatched/Generated/Query/Test/Data.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data.php
@@ -34,6 +34,7 @@ final class Data
      *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
+     *     ...<string, HookLoader<array<int, mixed>, mixed>>,
      * }
      */
     private readonly array $loaders;
@@ -48,18 +49,23 @@ final class Data
      *             'name': string,
      *             'ownerId': string,
      *             'reviewerId': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'computeAccess': ComputeAccessHook,
      *     'findOrgPlan': FindOrgPlanHook,
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
@@ -42,12 +42,15 @@ final class Organization
      *         'name': string,
      *         'ownerId': string,
      *         'reviewerId': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
+     *     ...<string, HookLoader<array<int, mixed>, mixed>>,
      * } $loaders
      */
     public function __construct(

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
@@ -42,10 +42,12 @@ final class Repository
      *     'name': string,
      *     'ownerId': string,
      *     'reviewerId': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
+     *     ...<string, HookLoader<array<int, mixed>, mixed>>,
      * } $loaders
      */
     public function __construct(

--- a/tests/HooksBatched/Generated/Query/Test/Error.php
+++ b/tests/HooksBatched/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksBatched/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksBatched/Generated/Query/Test/TestQuery.php
@@ -34,6 +34,7 @@ final readonly class TestQuery {
      *     'computeAccess': ComputeAccessHook,
      *     'findOrgPlan': FindOrgPlanHook,
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
@@ -30,15 +30,19 @@ final class Data
      *         'id': string,
      *         'realFieldA'?: string,
      *         'realFieldB'?: string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
@@ -82,9 +82,11 @@ final class Thing
      *     'id': string,
      *     'realFieldA'?: string,
      *     'realFieldB'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantA.php
@@ -28,9 +28,11 @@ final class AsVariantA
      *     '__typename': 'VariantA',
      *     'id': string,
      *     'realFieldA': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing/AsVariantB.php
@@ -16,6 +16,7 @@ final class AsVariantB
      * @param array{
      *     '__typename': 'VariantB',
      *     'realFieldB': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Error.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/TestQuery.php
@@ -31,6 +31,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow.php
@@ -25,10 +25,13 @@ final class ShowPaymentFlow
      *     'order': array{
      *         'discountId': string,
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow/Order.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Fragment/ShowPaymentFlow/Order.php
@@ -27,9 +27,11 @@ final class Order
      * @param array{
      *     'discountId': string,
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data.php
@@ -31,16 +31,21 @@ final class Data
      *         'order': array{
      *             'discountId': string,
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data/PaymentFlow.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Data/PaymentFlow.php
@@ -21,10 +21,13 @@ final class PaymentFlow
      *     'order': array{
      *         'discountId': string,
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Error.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksThroughSoleFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -32,6 +32,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findDiscountCodeById': FindDiscountCodeByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data.php
@@ -30,18 +30,24 @@ final class Data
      *         'projects': list<array{
      *             'creator': array{
      *                 'id': string,
+     *                 ...<int|string, mixed>,
      *             },
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer.php
@@ -36,12 +36,16 @@ final class Viewer
      *     'projects': list<array{
      *         'creator': array{
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project.php
@@ -28,11 +28,14 @@ final class Project
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -15,6 +15,7 @@ final class Creator
     /**
      * @param array{
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Error.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithCustomTypeInitializer/Generated/Query/Test/TestQuery.php
@@ -32,6 +32,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectListing.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectListing.php
@@ -22,12 +22,15 @@ final class ProjectListing
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary.php
@@ -28,11 +28,14 @@ final class ProjectSummary
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary/Creator.php
+++ b/tests/HooksWithFragmentSpread/Generated/Fragment/ProjectSummary/Creator.php
@@ -15,6 +15,7 @@ final class Creator
     /**
      * @param array{
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data.php
@@ -27,19 +27,25 @@ final class Data
      *         'projects': list<array{
      *             'creator': array{
      *                 'id': string,
+     *                 ...<int|string, mixed>,
      *             },
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer.php
@@ -28,13 +28,17 @@ final class Viewer
      *     'projects': list<array{
      *         'creator': array{
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Data/Viewer/Project.php
@@ -19,12 +19,15 @@ final class Project
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/Error.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithFragmentSpread/Generated/Query/Test/TestQuery.php
@@ -39,6 +39,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data.php
@@ -27,16 +27,21 @@ final class Data
      *         'projects': list<array{
      *             'contributorIds': list<string>,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUsersByIds': FindUsersByIdsHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer.php
@@ -28,10 +28,13 @@ final class Viewer
      *     'projects': list<array{
      *         'contributorIds': list<string>,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUsersByIds': FindUsersByIdsHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Data/Viewer/Project.php
@@ -33,9 +33,11 @@ final class Project
      * @param array{
      *     'contributorIds': list<string>,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUsersByIds': FindUsersByIdsHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithListReturn/Generated/Query/Test/Error.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithListReturn/Generated/Query/Test/TestQuery.php
@@ -27,6 +27,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUsersByIds': FindUsersByIdsHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data.php
@@ -27,19 +27,25 @@ final class Data
      *         'projects': list<array{
      *             'creator': array{
      *                 'id': string,
+     *                 ...<int|string, mixed>,
      *             },
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer.php
@@ -28,13 +28,17 @@ final class Viewer
      *     'projects': list<array{
      *         'creator': array{
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project.php
@@ -32,12 +32,15 @@ final class Project
      * @param array{
      *     'creator': array{
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project/Creator.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Data/Viewer/Project/Creator.php
@@ -15,6 +15,7 @@ final class Creator
     /**
      * @param array{
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Error.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
+++ b/tests/HooksWithSymfonyAutowire/Generated/Query/Test/TestQuery.php
@@ -31,6 +31,7 @@ final readonly class TestQuery {
     /**
      * @param array{
      *     'findUserById': FindUserByIdHook,
+     *     ...<int|string, mixed>,
      * } $hooks
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data.php
@@ -73,21 +73,27 @@ final class Data
      * @param array{
      *     'admin'?: array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'admin2'?: array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'user2': array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'viewer': array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Admin.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Admin.php
@@ -15,6 +15,7 @@ final class Admin
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Admin2.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Admin2.php
@@ -15,6 +15,7 @@ final class Admin2
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/User2.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/User2.php
@@ -15,6 +15,7 @@ final class User2
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Viewer.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Data/Viewer.php
@@ -15,6 +15,7 @@ final class Viewer
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IncludeAndSkipDirective/Generated/Query/Test/Error.php
+++ b/tests/IncludeAndSkipDirective/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/IndexByDirective/Generated/Query/Test/Data.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data.php
@@ -48,22 +48,29 @@ final class Data
      *             'node': array{
      *                 'id': int,
      *                 'name': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
      *     'issues': list<array{
      *         'id': int,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'projects': list<array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection.php
@@ -34,8 +34,11 @@ final class CustomerConnection
      *         'node': array{
      *             'id': int,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection/CustomerEdge.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection/CustomerEdge.php
@@ -19,7 +19,9 @@ final class CustomerEdge
      *     'node': array{
      *         'id': int,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection/CustomerEdge/Customer.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data/CustomerConnection/CustomerEdge/Customer.php
@@ -20,6 +20,7 @@ final class Customer
      * @param array{
      *     'id': int,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Data/Issue.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data/Issue.php
@@ -20,6 +20,7 @@ final class Issue
      * @param array{
      *     'id': int,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Data/Project.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Data/Project.php
@@ -20,6 +20,7 @@ final class Project
      * @param array{
      *     'id': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/Test/Error.php
+++ b/tests/IndexByDirective/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data.php
@@ -52,22 +52,29 @@ final class Data
      *             'node': array{
      *                 'id': int,
      *                 'name': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
      *     'issues': list<array{
      *         'id': int,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'projects': list<array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection.php
@@ -47,8 +47,11 @@ final class CustomerConnection
      *         'node': array{
      *             'id': int,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge.php
@@ -19,7 +19,9 @@ final class CustomerEdge
      *     'node': array{
      *         'id': int,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge/Customer.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/CustomerConnection/CustomerEdge/Customer.php
@@ -20,6 +20,7 @@ final class Customer
      * @param array{
      *     'id': int,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Issue.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Issue.php
@@ -20,6 +20,7 @@ final class Issue
      * @param array{
      *     'id': int,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Project.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Data/Project.php
@@ -20,6 +20,7 @@ final class Project
      * @param array{
      *     'id': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
+++ b/tests/IndexByDirective/Generated/Query/TestMultiField/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/InlineFragment/Generated/Fragment/UserName56995d/UserName.php
+++ b/tests/InlineFragment/Generated/Fragment/UserName56995d/UserName.php
@@ -33,6 +33,7 @@ final class UserName
      *     'firstName': string,
      *     'id': string,
      *     'lastName': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data.php
@@ -35,12 +35,15 @@ final class Data
      *         'firstName': string,
      *         'id': string,
      *         'lastName': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data/FeaturedUser.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Data/FeaturedUser.php
@@ -26,6 +26,7 @@ final class FeaturedUser
      *     'firstName': string,
      *     'id': string,
      *     'lastName': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Error.php
+++ b/tests/InlineFragment/Generated/Query/FeaturedUsers5a9829/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data.php
@@ -35,12 +35,15 @@ final class Data
      *         'firstName': string,
      *         'id': string,
      *         'lastName': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data/User.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Data/User.php
@@ -26,6 +26,7 @@ final class User
      *     'firstName': string,
      *     'id': string,
      *     'lastName': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragment/Generated/Query/ListUsers9908fe/Error.php
+++ b/tests/InlineFragment/Generated/Query/ListUsers9908fe/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
@@ -29,12 +29,15 @@ final class Data
      *         'code'?: string,
      *         'id'?: string,
      *         'name'?: string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
@@ -86,6 +86,7 @@ final class AddCountry
      *     'code'?: string,
      *     'id'?: string,
      *     'name'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsCountry.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsCountry.php
@@ -21,6 +21,7 @@ final class AsCountry
      *     '__typename': 'Country',
      *     'id': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsSupportedCountryError.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsSupportedCountryError.php
@@ -18,6 +18,7 @@ final class AsSupportedCountryError
     /**
      * @param array{
      *     '__typename': 'SupportedCountryError',
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsUnsupportedCountryError.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry/AsUnsupportedCountryError.php
@@ -20,6 +20,7 @@ final class AsUnsupportedCountryError
      * @param array{
      *     '__typename': 'UnsupportedCountryError',
      *     'code': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Error.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/InlineFragments/Generated/Query/Test/Data.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data.php
@@ -33,18 +33,22 @@ final class Data
      *         'description': null|string,
      *         'name': string,
      *         'state': null|string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'viewer': array{
      *         '__typename': string,
      *         'login'?: string,
      *         'name': string,
      *         'url'?: string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Data/Project.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Project.php
@@ -25,6 +25,7 @@ final class Project
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
@@ -73,6 +73,7 @@ final class Viewer
      *     'login'?: string,
      *     'name': string,
      *     'url'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsApplication.php
@@ -16,6 +16,7 @@ final class AsApplication
      * @param array{
      *     '__typename': 'Application',
      *     'url': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -16,6 +16,7 @@ final class AsUser
      * @param array{
      *     '__typename': 'User',
      *     'login': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Error.php
+++ b/tests/InlineFragments/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data.php
@@ -33,13 +33,17 @@ final class Data
      *         'projects': list<array{
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data/Viewer.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data/Viewer.php
@@ -34,7 +34,9 @@ final class Viewer
      *     'projects': list<array{
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data/Viewer/Project.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Data/Viewer/Project.php
@@ -36,6 +36,7 @@ final class Project
      * @param array{
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Error.php
+++ b/tests/InlineProcessing/Generated/Query/ViewerProjects1d8480/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Input/Generated/Mutation/Test/Data.php
+++ b/tests/Input/Generated/Mutation/Test/Data.php
@@ -31,11 +31,13 @@ final class Data
      * @param array{
      *     'createUser': bool,
      *     'sayHello': string,
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Input/Generated/Mutation/Test/Error.php
+++ b/tests/Input/Generated/Mutation/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/ListScalar/Generated/Query/Test/Data.php
+++ b/tests/ListScalar/Generated/Query/Test/Data.php
@@ -33,12 +33,15 @@ final class Data
      *     'wallet': array{
      *         'currencies': list<string>,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/ListScalar/Generated/Query/Test/Data/Wallet.php
+++ b/tests/ListScalar/Generated/Query/Test/Data/Wallet.php
@@ -25,6 +25,7 @@ final class Wallet
      * @param array{
      *     'currencies': list<string>,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ListScalar/Generated/Query/Test/Error.php
+++ b/tests/ListScalar/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/ListTypename/Generated/Query/Test/Data.php
+++ b/tests/ListTypename/Generated/Query/Test/Data.php
@@ -25,19 +25,25 @@ final class Data
      *         'multiList': list<array{
      *             '__typename': string,
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         }>,
      *         'single': array{
      *             '__typename': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'soleList': list<array{
      *             '__typename': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/ListTypename/Generated/Query/Test/Data/Field.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field.php
@@ -35,13 +35,17 @@ final class Field
      *     'multiList': list<array{
      *         '__typename': string,
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'single': array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'soleList': list<array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/MultiList.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/MultiList.php
@@ -20,6 +20,7 @@ final class MultiList
      * @param array{
      *     '__typename': string,
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/Single.php
@@ -18,6 +18,7 @@ final class Single
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ListTypename/Generated/Query/Test/Data/Field/SoleList.php
+++ b/tests/ListTypename/Generated/Query/Test/Data/Field/SoleList.php
@@ -18,6 +18,7 @@ final class SoleList
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ListTypename/Generated/Query/Test/Error.php
+++ b/tests/ListTypename/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Money/Generated/Fragment/Converter.php
+++ b/tests/Money/Generated/Fragment/Converter.php
@@ -35,6 +35,7 @@ final class Converter
      *         'amount': numeric-string,
      *         'currency': string,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Money/Generated/Query/ConvertMoney/Data.php
+++ b/tests/Money/Generated/Query/ConvertMoney/Data.php
@@ -42,11 +42,13 @@ final class Data
      *         'amount': numeric-string,
      *         'currency': string,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Money/Generated/Query/ConvertMoney/Error.php
+++ b/tests/Money/Generated/Query/ConvertMoney/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/MutationTypename/Generated/Mutation/Test/Data.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data.php
@@ -42,21 +42,27 @@ final class Data
      * @param array{
      *     'fireAndForget': array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'nested': array{
      *         'inner': array{
      *             '__typename': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
      *     'withExtraFields': array{
      *         '__typename': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/FireAndForget.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/FireAndForget.php
@@ -18,6 +18,7 @@ final class FireAndForget
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/Nested.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/Nested.php
@@ -18,7 +18,9 @@ final class Nested
      * @param array{
      *     'inner': array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/Nested/Inner.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/Nested/Inner.php
@@ -18,6 +18,7 @@ final class Inner
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/MutationTypename/Generated/Mutation/Test/Data/WithExtraFields.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Data/WithExtraFields.php
@@ -20,6 +20,7 @@ final class WithExtraFields
      * @param array{
      *     '__typename': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/MutationTypename/Generated/Mutation/Test/Error.php
+++ b/tests/MutationTypename/Generated/Mutation/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/NoIndexBy/Generated/Query/Test/Data.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data.php
@@ -33,17 +33,25 @@ final class Data
      *                         'items': list<array{
      *                             '__typename': string,
      *                             'id': string,
+     *                             ...<int|string, mixed>,
      *                         }>,
+     *                         ...<int|string, mixed>,
      *                     },
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions.php
@@ -41,11 +41,17 @@ final class Transactions
      *                     'items': list<array{
      *                         '__typename': string,
      *                         'id': string,
+     *                         ...<int|string, mixed>,
      *                     }>,
+     *                     ...<int|string, mixed>,
      *                 },
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge.php
@@ -26,10 +26,15 @@ final class Edge
      *                 'items': list<array{
      *                     '__typename': string,
      *                     'id': string,
+     *                     ...<int|string, mixed>,
      *                 }>,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node.php
@@ -29,9 +29,13 @@ final class Node
      *             'items': list<array{
      *                 '__typename': string,
      *                 'id': string,
+     *                 ...<int|string, mixed>,
      *             }>,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow.php
@@ -23,8 +23,11 @@ final class Workflow
      *         'items': list<array{
      *             '__typename': string,
      *             'id': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow/Request.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow/Request.php
@@ -29,7 +29,9 @@ final class Request
      *     'items': list<array{
      *         '__typename': string,
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow/Request/Item.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Data/Transactions/Edge/Node/Workflow/Request/Item.php
@@ -23,6 +23,7 @@ final class Item
      * @param array{
      *     '__typename': string,
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NoIndexBy/Generated/Query/Test/Error.php
+++ b/tests/NoIndexBy/Generated/Query/Test/Error.php
@@ -17,6 +17,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/NullableConnections/Generated/Query/Test/Data.php
+++ b/tests/NullableConnections/Generated/Query/Test/Data.php
@@ -27,14 +27,19 @@ final class Data
      *             'node': array{
      *                 'id': string,
      *                 'name': string,
+     *                 ...<int|string, mixed>,
      *             },
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection.php
+++ b/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection.php
@@ -24,8 +24,11 @@ final class ProjectConnection
      *         'node': array{
      *             'id': string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection/ProjectEdge.php
+++ b/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection/ProjectEdge.php
@@ -24,7 +24,9 @@ final class ProjectEdge
      *     'node': array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection/ProjectEdge/Project.php
+++ b/tests/NullableConnections/Generated/Query/Test/Data/ProjectConnection/ProjectEdge/Project.php
@@ -20,6 +20,7 @@ final class Project
      * @param array{
      *     'id': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/NullableConnections/Generated/Query/Test/Error.php
+++ b/tests/NullableConnections/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/OneOfDirective/Generated/Query/Test/Data.php
+++ b/tests/OneOfDirective/Generated/Query/Test/Data.php
@@ -24,12 +24,15 @@ final class Data
      *     'user': null|array{
      *         'email': string,
      *         'id': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/OneOfDirective/Generated/Query/Test/Data/User.php
+++ b/tests/OneOfDirective/Generated/Query/Test/Data/User.php
@@ -20,6 +20,7 @@ final class User
      * @param array{
      *     'email': string,
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/OneOfDirective/Generated/Query/Test/Error.php
+++ b/tests/OneOfDirective/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Optimization/Generated/Fragment/AppName.php
+++ b/tests/Optimization/Generated/Fragment/AppName.php
@@ -15,6 +15,7 @@ final class AppName
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Fragment/AppUrl.php
+++ b/tests/Optimization/Generated/Fragment/AppUrl.php
@@ -20,6 +20,7 @@ final class AppUrl
      * @param array{
      *     'name': string,
      *     'url': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Data.php
+++ b/tests/Optimization/Generated/Query/Test/Data.php
@@ -33,6 +33,7 @@ final class Data
      *         'description': null|string,
      *         'name': string,
      *         'state': null|string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'viewer': array{
      *         '__typename': string,
@@ -41,12 +42,15 @@ final class Data
      *         'login'?: string,
      *         'name': string,
      *         'url'?: string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Data/Project.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Project.php
@@ -25,6 +25,7 @@ final class Project
      *     'description': null|string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer.php
@@ -91,6 +91,7 @@ final class Viewer
      *     'login'?: string,
      *     'name': string,
      *     'url'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer/AsUser.php
@@ -21,6 +21,7 @@ final class AsUser
      *     '__typename': 'User',
      *     'login': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Error.php
+++ b/tests/Optimization/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Planner/PayloadShapeBuilderTest.php
+++ b/tests/Planner/PayloadShapeBuilderTest.php
@@ -186,6 +186,7 @@ final class PayloadShapeBuilderTest extends TestCase
             <<<'PHPDOC'
                 array{
                     'id': string,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -217,7 +218,9 @@ final class PayloadShapeBuilderTest extends TestCase
                     'user': null|array{
                         'email': null|string,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -247,7 +250,9 @@ final class PayloadShapeBuilderTest extends TestCase
                     'users': list<array{
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -318,12 +323,16 @@ final class PayloadShapeBuilderTest extends TestCase
                         'canBeCollected': bool,
                         'customer': null|array{
                             'id': string,
+                            ...<int|string, mixed>,
                         },
                         'id': string,
                         'transferReversals': list<array{
                             'id': string,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -363,6 +372,7 @@ final class PayloadShapeBuilderTest extends TestCase
                     'email'?: string,
                     'id': string,
                     'role'?: string,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -424,7 +434,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'age': null|int,
                         'email': null|string,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -451,6 +463,7 @@ final class PayloadShapeBuilderTest extends TestCase
                 array{
                     '__typename': string,
                     'id': string,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -486,7 +499,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'lastSeen': null|scalar,
                         'metadata': null|scalar,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -555,10 +570,13 @@ final class PayloadShapeBuilderTest extends TestCase
                         'createdAt': string,
                         'customer': null|array{
                             'name': string,
+                            ...<int|string, mixed>,
                         },
                         'id': string,
                         'state': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -626,8 +644,11 @@ final class PayloadShapeBuilderTest extends TestCase
                             'canBeCollected': bool,
                             'id': string,
                             'state': string,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -770,13 +791,17 @@ final class PayloadShapeBuilderTest extends TestCase
                             'customer': null|array{
                                 'id': string,
                                 'name': string,
+                                ...<int|string, mixed>,
                             },
                             'id': string,
                             'state': string,
                             'transferReversals': list<array{
                                 'id': string,
+                                ...<int|string, mixed>,
                             }>,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     }>,
                     'transaction': null|array{
                         'id': string,
@@ -786,24 +811,31 @@ final class PayloadShapeBuilderTest extends TestCase
                             'customer': null|array{
                                 'id': string,
                                 'name': string,
+                                ...<int|string, mixed>,
                             },
                             'id': string,
                             'state': string,
                             'transferReversals': list<array{
                                 'id': string,
+                                ...<int|string, mixed>,
                             }>,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     },
                     'user': null|array{
                         'email': null|string,
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
                     'users': list<array{
                         'email': null|string,
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -865,13 +897,17 @@ final class PayloadShapeBuilderTest extends TestCase
                         'transfers'?: list<array{
                             'id': string,
                             'state': string,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     },
                     'user'?: null|array{
                         'email': null|string,
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -928,11 +964,14 @@ final class PayloadShapeBuilderTest extends TestCase
                         'email'?: null|string,
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     },
                     'users'?: list<array{
                         'id': string,
                         'name': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1003,13 +1042,17 @@ final class PayloadShapeBuilderTest extends TestCase
                         'transfers': list<array{
                             'id': string,
                             'state'?: string,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     },
                     'user': null|array{
                         'email'?: null|string,
                         'id': string,
                         'name'?: string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1161,10 +1204,13 @@ final class PayloadShapeBuilderTest extends TestCase
                             'canBeCollected': bool,
                             'customer': null|array{
                                 'id': string,
+                                ...<int|string, mixed>,
                             },
                             'id': string,
                             'state': string,
+                            ...<int|string, mixed>,
                         }>,
+                        ...<int|string, mixed>,
                     }>,
                     'user': null|array{
                         'email': null|string,
@@ -1176,14 +1222,18 @@ final class PayloadShapeBuilderTest extends TestCase
                             'age': null|int,
                             'email': null|string,
                             'name': string,
+                            ...<int|string, mixed>,
                         },
+                        ...<int|string, mixed>,
                     },
                     'viewer': null|array{
                         'address'?: null|string,
                         'email'?: string,
                         'id': string,
                         'role'?: string,
+                        ...<int|string, mixed>,
                     },
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1240,7 +1290,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'lastName'?: string,
                         'role'?: string,
                         'teamSize'?: int,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1331,7 +1383,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'lastName'?: string,
                         'role'?: string,
                         'teamSize'?: int,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1376,7 +1430,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'lastName'?: string,
                         'role'?: string,
                         'teamSize'?: int,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1468,7 +1524,9 @@ final class PayloadShapeBuilderTest extends TestCase
                         'lastName'?: string,
                         'role'?: string,
                         'teamSize'?: int,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1529,7 +1587,9 @@ final class PayloadShapeBuilderTest extends TestCase
                     'canBeCollected': bool,
                     'transferReversals': list<array{
                         'id': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1588,9 +1648,12 @@ final class PayloadShapeBuilderTest extends TestCase
                     'transfers': list<array{
                         'customer': null|array{
                             'id': string,
+                            ...<int|string, mixed>,
                         },
                         'id': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -1619,9 +1682,12 @@ final class PayloadShapeBuilderTest extends TestCase
                         'canBeCollected': bool,
                         'customer': null|array{
                             'id': string,
+                            ...<int|string, mixed>,
                         },
                         'id': string,
+                        ...<int|string, mixed>,
                     }>,
+                    ...<int|string, mixed>,
                 }
                 PHPDOC,
             TypeDumper::dump($shape2->toArrayShape()),

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data.php
@@ -30,22 +30,29 @@ final class Data
      *         '__typename': string,
      *         'fxFee'?: null|array{
      *             '__typename': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'id'?: string,
+     *         ...<int|string, mixed>,
      *     },
      *     'supportedCountry': array{
      *         'error': null|array{
      *             '__typename': string,
+     *             ...<int|string, mixed>,
      *         },
      *         'info': null|array{
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
@@ -45,8 +45,10 @@ final class Order
      *     '__typename': string,
      *     'fxFee'?: null|array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'id'?: string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem.php
@@ -23,8 +23,10 @@ final class AsMarketPlaceOrderItem
      *     '__typename': 'MarketPlaceOrderItem',
      *     'fxFee': null|array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'id': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem/FxFee.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order/AsMarketPlaceOrderItem/FxFee.php
@@ -18,6 +18,7 @@ final class FxFee
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry.php
@@ -23,10 +23,13 @@ final class SupportedCountry
      * @param array{
      *     'error': null|array{
      *         '__typename': string,
+     *         ...<int|string, mixed>,
      *     },
      *     'info': null|array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Error.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Error.php
@@ -18,6 +18,7 @@ final class Error
     /**
      * @param array{
      *     '__typename': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Info.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/SupportedCountry/Info.php
@@ -15,6 +15,7 @@ final class Info
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/QueryObjectTypename/Generated/Query/Test/Error.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Simple/Generated/Query/Test/Data.php
+++ b/tests/Simple/Generated/Query/Test/Data.php
@@ -26,13 +26,17 @@ final class Data
      *         'projects': list<array{
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Simple/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Simple/Generated/Query/Test/Data/Viewer.php
@@ -27,7 +27,9 @@ final class Viewer
      *     'projects': list<array{
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Simple/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/Simple/Generated/Query/Test/Data/Viewer/Project.php
@@ -20,6 +20,7 @@ final class Project
      * @param array{
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Simple/Generated/Query/Test/Error.php
+++ b/tests/Simple/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data.php
@@ -23,12 +23,15 @@ final class Data
      * @param array{
      *     'viewer': array{
      *         'login': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data/Viewer.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Data/Viewer.php
@@ -15,6 +15,7 @@ final class Viewer
     /**
      * @param array{
      *     'login': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Error.php
+++ b/tests/StaleImportRemoval/Generated/Query/GetViewer6b9a6d/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/SymfonyExclude/Generated/Query/Test/Data.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/Data.php
@@ -28,13 +28,17 @@ final class Data
      *         'projects': list<array{
      *             'description': null|string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         }>,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/SymfonyExclude/Generated/Query/Test/Data/Viewer.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/Data/Viewer.php
@@ -29,7 +29,9 @@ final class Viewer
      *     'projects': list<array{
      *         'description': null|string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     }>,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/SymfonyExclude/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/Data/Viewer/Project.php
@@ -23,6 +23,7 @@ final class Project
      * @param array{
      *     'description': null|string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/SymfonyExclude/Generated/Query/Test/Error.php
+++ b/tests/SymfonyExclude/Generated/Query/Test/Error.php
@@ -17,6 +17,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -41,7 +41,7 @@ final readonly class TestClient
         );
         $response = $this->client->sendRequest($request);
         Assert::same(200, $response->getStatusCode(), 'GraphQL server responded with a %2$s status code.');
-        $data = json_decode((string) $response->getBody(), true, JSON_THROW_ON_ERROR);
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
         Assert::isArray($data, 'GraphQL server did not return an array.');
 
         return $data;

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data.php
@@ -31,13 +31,17 @@ final class Data
      *         'project': null|array{
      *             'id': string,
      *             'name': string,
+     *             ...<int|string, mixed>,
      *         },
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer.php
@@ -36,7 +36,9 @@ final class Viewer
      *     'project': null|array{
      *         'id': string,
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer/Project.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Data/Viewer/Project.php
@@ -20,6 +20,7 @@ final class Project
      * @param array{
      *     'id': string,
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/ThrowWhenNullDirective/Generated/Query/Test/Error.php
+++ b/tests/ThrowWhenNullDirective/Generated/Query/Test/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)

--- a/tests/Twig/Generated/Fragment/AdminProjectList.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList.php
@@ -35,10 +35,13 @@ final class AdminProjectList
      *         'id': string,
      *         'name': string,
      *         'state': null|string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'viewer': array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Twig/Generated/Fragment/AdminProjectList/Project.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList/Project.php
@@ -26,6 +26,7 @@ final class Project
      *     'id': string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectList/Viewer.php
@@ -22,6 +22,7 @@ final class Viewer
     /**
      * @param array{
      *     'name': string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Twig/Generated/Fragment/AdminProjectOptions.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectOptions.php
@@ -31,6 +31,7 @@ final class AdminProjectOptions
     /**
      * @param array{
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Twig/Generated/Fragment/AdminProjectRow.php
+++ b/tests/Twig/Generated/Fragment/AdminProjectRow.php
@@ -45,6 +45,7 @@ final class AdminProjectRow
      *     'id': string,
      *     'name': string,
      *     'state': null|string,
+     *     ...<int|string, mixed>,
      * } $data
      */
     public function __construct(

--- a/tests/Twig/Generated/Query/Projectsd4cba6/Data.php
+++ b/tests/Twig/Generated/Query/Projectsd4cba6/Data.php
@@ -33,15 +33,19 @@ final class Data
      *         'id': string,
      *         'name': string,
      *         'state': null|string,
+     *         ...<int|string, mixed>,
      *     }>,
      *     'viewer': array{
      *         'name': string,
+     *         ...<int|string, mixed>,
      *     },
+     *     ...<int|string, mixed>,
      * } $data
      * @param list<array{
      *     'code': string,
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * }> $errors
      */
     public function __construct(

--- a/tests/Twig/Generated/Query/Projectsd4cba6/Error.php
+++ b/tests/Twig/Generated/Query/Projectsd4cba6/Error.php
@@ -14,6 +14,7 @@ final readonly class Error
      * @param array{
      *     'debugMessage'?: string,
      *     'message': string,
+     *     ...<int|string, mixed>,
      * } $error
      */
     public function __construct(array $error)


### PR DESCRIPTION

### Bump to PHPStan 2.2

### Pass JSON_THROW_ON_ERROR as $flags, not $depth

PHPStan 2.2 flags the constant in the third arg of `json_decode`, since `$depth` only accepts integer depths. Move it to the `$flags` slot with the default depth of 512.

### Unseal generated array shapes for PHPStan 2.2

PHPStan 2.2 enforces sealed array shapes by default, rejecting the generator's pattern where a parent forwards `$this->data` (or a wider loaders registry) into a child fragment, inline-fragment, error, or loader constructor that declared a narrower shape. The forwarding is structurally correct — children only read the keys they declare — but the sealed-shape rule treats the extras as type errors.

Mark generated payload, error, hooks, and loaders shapes as unsealed so the wider parent shape fits. `HookLoader`'s template params become `@template-covariant` so any specific instantiation fits the unsealed extras slot in nested classes' `\$loaders` parameter. Input object shapes stay sealed — those describe a closed GraphQL input schema and are constructed by user code with exactly the declared fields.

Extras are emitted explicitly as `...<int|string, mixed>` rather than the short `...`, since PHPStan's `missingType.iterableValue` rule at level 6+ rejects the implicit `array-key, mixed` extras.
