### PR TITLE
Type catch-all HookLoader extras as `<mixed, mixed>`

### DIFF
--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -183,7 +183,7 @@ final class DataClassGenerator extends AbstractGenerator
         // which holds every batched hook in the operation, not just the subset a
         // single nested class consumes. Extras are typed wide; HookLoader's
         // covariant template params let any specific instantiation fit here.
-        $entries[] = sprintf('...<string, %s<array{...}, mixed>>', $hookLoader);
+        $entries[] = sprintf('...<string, %s<mixed, mixed>>', $hookLoader);
 
         return sprintf("array{\n    %s,\n}", implode(",\n    ", $entries));
     }

--- a/tests/HooksBatched/Generated/Query/Test/Data.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data.php
@@ -34,7 +34,7 @@ final class Data
      *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
-     *     ...<string, HookLoader<array{...}, mixed>>,
+     *     ...<string, HookLoader<mixed, mixed>>,
      * }
      */
     private readonly array $loaders;

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization.php
@@ -50,7 +50,7 @@ final class Organization
      *     findOrgPlan: HookLoader<array{string}, OrgPlan>,
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
-     *     ...<string, HookLoader<array{...}, mixed>>,
+     *     ...<string, HookLoader<mixed, mixed>>,
      * } $loaders
      */
     public function __construct(

--- a/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
+++ b/tests/HooksBatched/Generated/Query/Test/Data/Organization/Repository.php
@@ -47,7 +47,7 @@ final class Repository
      * @param array{
      *     computeAccess: HookLoader<array{string, string}, Access>,
      *     findUserById: HookLoader<array{string}, null|User>,
-     *     ...<string, HookLoader<array{...}, mixed>>,
+     *     ...<string, HookLoader<mixed, mixed>>,
      * } $loaders
      */
     public function __construct(


### PR DESCRIPTION
`array{...}` was an awkward stand-in for the widest input tuple type.
Since `HookLoader`'s template params are covariant, the catch-all entry
in the loaders shape can just use `mixed` for both — semantically the
widest possible, and any concrete `HookLoader<array{...}, X>` still fits.