### PR TITLE
Emit polymorphic payloads as unions of sealed arms

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,26 @@ final class Data
      * @param array{
      *     'search': array{
      *         'nodes': null|list<null|array{
-     *             '__typename': string,
-     *             'merged'?: bool,
-     *             'number'?: int,
-     *             'title'?: string,
-     *             ...,
+     *             '__typename': 'App',
+     *         }|array{
+     *             '__typename': 'Discussion',
+     *         }|array{
+     *             '__typename': 'Issue',
+     *             'number': int,
+     *             'title': string,
+     *         }|array{
+     *             '__typename': 'MarketplaceListing',
+     *         }|array{
+     *             '__typename': 'Organization',
+     *         }|array{
+     *             '__typename': 'PullRequest',
+     *             'merged': bool,
+     *             'number': int,
+     *             'title': string,
+     *         }|array{
+     *             '__typename': 'Repository',
+     *         }|array{
+     *             '__typename': 'User',
      *         }>,
      *         ...,
      *     },

--- a/examples/Generated/Query/Search/Data.php
+++ b/examples/Generated/Query/Search/Data.php
@@ -37,11 +37,26 @@ final class Data
      * @param array{
      *     'search': array{
      *         'nodes': null|list<null|array{
-     *             '__typename': string,
-     *             'merged'?: bool,
-     *             'number'?: int,
-     *             'title'?: string,
-     *             ...,
+     *             '__typename': 'App',
+     *         }|array{
+     *             '__typename': 'Discussion',
+     *         }|array{
+     *             '__typename': 'Issue',
+     *             'number': int,
+     *             'title': string,
+     *         }|array{
+     *             '__typename': 'MarketplaceListing',
+     *         }|array{
+     *             '__typename': 'Organization',
+     *         }|array{
+     *             '__typename': 'PullRequest',
+     *             'merged': bool,
+     *             'number': int,
+     *             'title': string,
+     *         }|array{
+     *             '__typename': 'Repository',
+     *         }|array{
+     *             '__typename': 'User',
      *         }>,
      *         ...,
      *     },

--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection.php
@@ -32,11 +32,26 @@ final class SearchResultItemConnection
     /**
      * @param array{
      *     'nodes': null|list<null|array{
-     *         '__typename': string,
-     *         'merged'?: bool,
-     *         'number'?: int,
-     *         'title'?: string,
-     *         ...,
+     *         '__typename': 'App',
+     *     }|array{
+     *         '__typename': 'Discussion',
+     *     }|array{
+     *         '__typename': 'Issue',
+     *         'number': int,
+     *         'title': string,
+     *     }|array{
+     *         '__typename': 'MarketplaceListing',
+     *     }|array{
+     *         '__typename': 'Organization',
+     *     }|array{
+     *         '__typename': 'PullRequest',
+     *         'merged': bool,
+     *         'number': int,
+     *         'title': string,
+     *     }|array{
+     *         '__typename': 'Repository',
+     *     }|array{
+     *         '__typename': 'User',
      *     }>,
      *     ...,
      * } $data

--- a/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
+++ b/examples/Generated/Query/Search/Data/SearchResultItemConnection/Node.php
@@ -26,25 +26,7 @@ final class Node
     }
 
     public ?AsIssue $asIssue {
-        get {
-            if (isset($this->asIssue)) {
-                return $this->asIssue;
-            }
-
-            if ($this->data['__typename'] !== 'Issue') {
-                return $this->asIssue = null;
-            }
-
-            if (! array_key_exists('number', $this->data)) {
-                return $this->asIssue = null;
-            }
-
-            if (! array_key_exists('title', $this->data)) {
-                return $this->asIssue = null;
-            }
-
-            return $this->asIssue = new AsIssue($this->data);
-        }
+        get => $this->asIssue ??= $this->data['__typename'] === 'Issue' ? new AsIssue($this->data) : null;
     }
 
     /**
@@ -56,29 +38,7 @@ final class Node
     }
 
     public ?PullRequestInfo $pullRequestInfo {
-        get {
-            if (isset($this->pullRequestInfo)) {
-                return $this->pullRequestInfo;
-            }
-
-            if ($this->data['__typename'] !== 'PullRequest') {
-                return $this->pullRequestInfo = null;
-            }
-
-            if (! array_key_exists('number', $this->data)) {
-                return $this->pullRequestInfo = null;
-            }
-
-            if (! array_key_exists('title', $this->data)) {
-                return $this->pullRequestInfo = null;
-            }
-
-            if (! array_key_exists('merged', $this->data)) {
-                return $this->pullRequestInfo = null;
-            }
-
-            return $this->pullRequestInfo = new PullRequestInfo($this->data);
-        }
+        get => $this->pullRequestInfo ??= $this->data['__typename'] === 'PullRequest' ? new PullRequestInfo($this->data) : null;
     }
 
     /**
@@ -91,11 +51,26 @@ final class Node
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'merged'?: bool,
-     *     'number'?: int,
-     *     'title'?: string,
-     *     ...,
+     *     '__typename': 'App',
+     * }|array{
+     *     '__typename': 'Discussion',
+     * }|array{
+     *     '__typename': 'Issue',
+     *     'number': int,
+     *     'title': string,
+     * }|array{
+     *     '__typename': 'MarketplaceListing',
+     * }|array{
+     *     '__typename': 'Organization',
+     * }|array{
+     *     '__typename': 'PullRequest',
+     *     'merged': bool,
+     *     'number': int,
+     *     'title': string,
+     * }|array{
+     *     '__typename': 'Repository',
+     * }|array{
+     *     '__typename': 'User',
      * } $data
      */
     public function __construct(

--- a/src/Generator/DataClassGenerator.php
+++ b/src/Generator/DataClassGenerator.php
@@ -800,51 +800,15 @@ final class DataClassGenerator extends AbstractGenerator
                                             return;
                                         }
 
-                                        // For fragments on concrete types when parent is interface/union
-                                        // We need to check both typename and required fields
-                                        if ($requiredFields === []) {
-                                            // No required fields to check, only typename
-                                            yield sprintf(
-                                                'get => $this->%s ??= $this->data[\'__typename\'] === %s ? %s : null;',
-                                                $fieldName,
-                                                var_export($nakedFieldType->fragmentType->name(), true),
-                                                $construct,
-                                            );
-                                        } else {
-                                            // Generate verbose getter with field checks for PHPStan type safety
-                                            yield 'get {';
-                                            yield $generator->indent(function () use ($fieldName, $nakedFieldType, $requiredFields, $construct) {
-                                                yield sprintf('if (isset($this->%s)) {', $fieldName);
-                                                yield '    return $this->' . $fieldName . ';';
-                                                yield '}';
-                                                yield '';
-                                                yield sprintf(
-                                                    'if ($this->data[\'__typename\'] !== %s) {',
-                                                    var_export($nakedFieldType->fragmentType->name(), true),
-                                                );
-                                                yield '    return $this->' . $fieldName . ' = null;';
-                                                yield '}';
-
-                                                // Check all required fields exist
-                                                foreach ($requiredFields as $requiredField) {
-                                                    yield '';
-                                                    yield sprintf(
-                                                        'if (! array_key_exists(%s, $this->data)) {',
-                                                        var_export($requiredField, true),
-                                                    );
-                                                    yield '    return $this->' . $fieldName . ' = null;';
-                                                    yield '}';
-                                                }
-
-                                                yield '';
-                                                yield sprintf(
-                                                    'return $this->%s = %s;',
-                                                    $fieldName,
-                                                    $construct,
-                                                );
-                                            });
-                                            yield '}';
-                                        }
+                                        // For fragments on concrete types when parent is interface/union,
+                                        // the union-of-sealed-arms payload shape lets PHPStan narrow
+                                        // by `__typename` alone — no `array_key_exists` guards needed.
+                                        yield sprintf(
+                                            'get => $this->%s ??= $this->data[\'__typename\'] === %s ? %s : null;',
+                                            $fieldName,
+                                            var_export($nakedFieldType->fragmentType->name(), true),
+                                            $construct,
+                                        );
 
                                         return;
                                     }

--- a/src/Planner/PayloadShape.php
+++ b/src/Planner/PayloadShape.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\Planner;
 
+use Ruudk\GraphQLCodeGenerator\Type\StringLiteralType;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 
 /**
@@ -15,6 +16,16 @@ final class PayloadShape
      * @var array<string, SymfonyType|array{type: SymfonyType, optional: bool}>
      */
     private array $shape = [];
+
+    /**
+     * Per-variant shapes for polymorphic selections (inline fragments on
+     * interface/union parents). Keyed by concrete type name; the stored
+     * `PayloadShape` only holds fields selected inside that variant's
+     * fragment, not the common fields from the parent selection set.
+     *
+     * @var array<string, PayloadShape>
+     */
+    private array $variants = [];
 
     public function addRequired(string $key, SymfonyType $type) : self
     {
@@ -33,9 +44,45 @@ final class PayloadShape
         return $this;
     }
 
+    public function addVariant(string $typeName, PayloadShape $variantShape) : self
+    {
+        // Always store an independent copy. The same source shape is reused
+        // when distributing an abstract fragment (e.g. `... on Person`) to
+        // every concrete implementor, and a shared reference would let one
+        // implementor's later additions leak into the others.
+        if ( ! isset($this->variants[$typeName])) {
+            $this->variants[$typeName] = new PayloadShape();
+        }
+
+        $this->variants[$typeName]->merge($variantShape);
+
+        // If the source shape itself carried a nested variant whose name
+        // matches the destination — e.g. distributing an `... on Person` shape
+        // (which has a nested `... on Employee` variant for `Developer`) to
+        // the `Developer` implementor — collapse those nested fields into
+        // this destination directly. Without this, fields from nested inline
+        // fragments would only live inside an unreachable second-level
+        // variant and never surface in the emitted arm.
+        if (isset($variantShape->variants[$typeName])) {
+            $this->variants[$typeName]->merge($variantShape->variants[$typeName]);
+        }
+
+        return $this;
+    }
+
     public function has(string $key) : bool
     {
         return isset($this->shape[$key]);
+    }
+
+    public function hasVariants() : bool
+    {
+        return $this->variants !== [];
+    }
+
+    public function hasVariant(string $typeName) : bool
+    {
+        return isset($this->variants[$typeName]);
     }
 
     /**
@@ -123,11 +170,58 @@ final class PayloadShape
             }
         }
 
+        foreach ($other->variants as $typeName => $variant) {
+            $this->addVariant($typeName, $asOptional ? $variant->withFieldsOptional() : $variant);
+        }
+
         return $this;
+    }
+
+    /**
+     * Return a copy with every direct field demoted to optional. Used when a
+     * conditional fragment (`@include`/`@skip`) contributes variant shapes —
+     * the variant arm exists, but each of its fields may or may not show up.
+     */
+    private function withFieldsOptional() : self
+    {
+        $clone = new self();
+
+        foreach ($this->shape as $key => $value) {
+            $type = is_array($value) ? $value['type'] : $value;
+            $clone->addOptional($key, $type);
+        }
+
+        foreach ($this->variants as $typeName => $variant) {
+            $clone->addVariant($typeName, $variant->withFieldsOptional());
+        }
+
+        return $clone;
     }
 
     public function toArrayShape() : SymfonyType
     {
-        return SymfonyType::arrayShape($this->shape, sealed: false);
+        if ($this->variants === []) {
+            return SymfonyType::arrayShape($this->shape, sealed: false);
+        }
+
+        $arms = [];
+
+        foreach ($this->variants as $typeName => $variant) {
+            $combined = $this->shape;
+
+            foreach ($variant->shape as $key => $value) {
+                $combined[$key] = $value;
+            }
+
+            $combined['__typename'] = new StringLiteralType($typeName);
+
+            // Arms must be sealed: PHPStan's narrowing on `__typename` literal
+            // only preserves required fields when each arm is sealed. Unsealed
+            // arms collapse to common-only after narrowing, dropping the
+            // variant-specific fields the variant subclass constructor needs.
+            $arms[] = SymfonyType::arrayShape($combined, sealed: true);
+        }
+
+        return count($arms) === 1 ? $arms[0] : SymfonyType::union(...$arms);
     }
 }

--- a/src/Planner/PayloadShapeBuilder.php
+++ b/src/Planner/PayloadShapeBuilder.php
@@ -22,6 +22,7 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Type\Schema;
+use Ruudk\GraphQLCodeGenerator\GraphQL\PossibleTypesFinder;
 use Ruudk\GraphQLCodeGenerator\TypeMapper;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
 use Webmozart\Assert\Assert;
@@ -34,6 +35,8 @@ use Webmozart\Assert\Assert;
  */
 final readonly class PayloadShapeBuilder
 {
+    private PossibleTypesFinder $possibleTypesFinder;
+
     /**
      * @param array<string, array{FragmentDefinitionNode, list<string>}> $fragmentDefinitions
      * @param array<string, Type&NamedType> $fragmentTypes
@@ -43,7 +46,9 @@ final readonly class PayloadShapeBuilder
         private TypeMapper $typeMapper,
         private array $fragmentDefinitions = [],
         private array $fragmentTypes = [],
-    ) {}
+    ) {
+        $this->possibleTypesFinder = new PossibleTypesFinder($this->schema);
+    }
 
     /**
      * Build a payload shape from a selection set
@@ -123,11 +128,29 @@ final readonly class PayloadShapeBuilder
                 $this->processFragmentSpread($selection, $shape, $parentType, $visitedFragments);
             }
         }
+
+        // When the parent is polymorphic and at least one concrete-type variant
+        // was registered, enumerate the schema's remaining possible types as
+        // empty variant arms. This keeps `__typename === 'X'` from being
+        // `always-true` when the client only wrote a fragment for one of
+        // several possible types: PHPStan sees the other typenames as live
+        // alternatives.
+        if (
+            $shape->hasVariants()
+            && ($parentType instanceof UnionType || $parentType instanceof InterfaceType)
+        ) {
+            foreach ($this->possibleTypesFinder->find($parentType) as $possibleTypeName) {
+                if ( ! $shape->hasVariant($possibleTypeName)) {
+                    $shape->addVariant($possibleTypeName, new PayloadShape());
+                }
+            }
+        }
     }
 
     /**
      * Collect all field selections including from same-type fragments
      * @param array<string, true> $visitedFragments
+     * @throws \GraphQL\Error\InvariantViolation
      * @return array<string, list<FieldNode>>
      */
     private function collectAllFieldSelections(
@@ -179,15 +202,25 @@ final readonly class PayloadShapeBuilder
 
             $fragmentType = $this->fragmentTypes[$fragmentName];
 
-            // Skip if different type
-            if ($fragmentType->name() !== $parentType->name()) {
-                continue;
-            }
-
             // Skip if parent is union/interface (needs special processing)
             $isUnionOrInterface = $parentType instanceof UnionType || $parentType instanceof InterfaceType;
 
             if ($isUnionOrInterface) {
+                continue;
+            }
+
+            $isSameType = $fragmentType->name() === $parentType->name();
+
+            // Collect direct fields when the spread is either same-type, or
+            // the concrete parent satisfies the fragment's abstract type
+            // (i.e. it implements the interface or is a union member). For
+            // implementor spreads the abstract fragment's fields are present
+            // unconditionally on the parent at runtime, so its direct fields
+            // belong in the same group.
+            if (
+                ! $isSameType
+                && ! ($parentType instanceof ObjectType && $this->parentSatisfiesAbstract($parentType, $fragmentType))
+            ) {
                 continue;
             }
 
@@ -344,15 +377,69 @@ final readonly class PayloadShapeBuilder
         $fragmentType = $this->schema->getType($fragmentTypeName);
         Assert::isInstanceOf($fragmentType, NamedType::class);
 
-        // Create a sub-shape for this fragment
+        $isSameType = $fragmentType->name() === $parentType->name();
+        $parentIsPolymorphic = $parentType instanceof UnionType || $parentType instanceof InterfaceType;
+
+        // Same-type fragment on union/interface spreads into common fields.
+        if ($isSameType && $parentIsPolymorphic) {
+            $this->processSelections($fragment->selectionSet, $fragmentType, $shape, $visitedFragments);
+
+            return;
+        }
+
+        // Polymorphic parent → variant arms keyed by concrete `__typename`.
+        if ($parentIsPolymorphic) {
+            $variantShape = new PayloadShape();
+            $this->processSelections($fragment->selectionSet, $fragmentType, $variantShape, $visitedFragments);
+            $this->distributeVariant($shape, $fragmentType, $variantShape);
+
+            return;
+        }
+
+        // Concrete parent that satisfies the fragment's type condition: process
+        // the inline fragment's selection set against the concrete parent so
+        // nested abstract spreads resolve in concrete context.
+        if (
+            $parentType instanceof ObjectType
+            && $this->parentSatisfiesAbstract($parentType, $fragmentType)
+        ) {
+            $this->processSelections($fragment->selectionSet, $parentType, $shape, $visitedFragments);
+
+            return;
+        }
+
+        // Fallback (concrete parent, different fragment type): merge with optional.
         $fragmentShape = new PayloadShape();
         $this->processSelections($fragment->selectionSet, $fragmentType, $fragmentShape, $visitedFragments);
-
-        // Determine if fields should be optional
         $isOptional = $this->shouldFieldsBeOptional($parentType, $fragmentType, false);
-
-        // Merge the fragment fields into the main shape
         $shape->merge($fragmentShape, $isOptional);
+    }
+
+    /**
+     * Add a fragment's fields to the appropriate variant arm(s). When the
+     * fragment type is an interface or union, the fields apply to every
+     * concrete implementor of that abstract type — we add the variant to each
+     * one. `__typename` only ever holds a concrete object type's name at
+     * runtime, so abstract type names never appear as their own arms.
+     *
+     * @throws \GraphQL\Error\InvariantViolation
+     */
+    private function distributeVariant(
+        PayloadShape $shape,
+        NamedType $fragmentType,
+        PayloadShape $variantShape,
+    ) : void {
+        if ($fragmentType instanceof ObjectType) {
+            $shape->addVariant($fragmentType->name(), $variantShape);
+
+            return;
+        }
+
+        if ($fragmentType instanceof UnionType || $fragmentType instanceof InterfaceType) {
+            foreach ($this->possibleTypesFinder->find($fragmentType) as $concreteTypeName) {
+                $shape->addVariant($concreteTypeName, $variantShape);
+            }
+        }
     }
 
     /**
@@ -381,14 +468,39 @@ final readonly class PayloadShapeBuilder
             $fragmentName => true,
         ];
 
-        // Determine if fields should be optional
         $hasDirective = $this->hasConditionalDirectives($spread);
         $isSameType = $fragmentType->name() === $parentType->name();
+        $parentIsPolymorphic = $parentType instanceof UnionType || $parentType instanceof InterfaceType;
 
         // For same-type interface/union fragments without directives,
         // merge directly to preserve field requiredness
-        if ($isSameType && ! $hasDirective && ($parentType instanceof UnionType || $parentType instanceof InterfaceType)) {
+        if ($isSameType && ! $hasDirective && $parentIsPolymorphic) {
             $this->processSelections($fragmentDef->selectionSet, $fragmentType, $shape, $newVisited);
+
+            return;
+        }
+
+        // Polymorphic parent → variant arms keyed by concrete `__typename`.
+        if ($parentIsPolymorphic && ! $hasDirective) {
+            $variantShape = new PayloadShape();
+            $this->processSelections($fragmentDef->selectionSet, $fragmentType, $variantShape, $newVisited);
+            $this->distributeVariant($shape, $fragmentType, $variantShape);
+
+            return;
+        }
+
+        // Concrete parent that satisfies the fragment's type condition (parent
+        // implements an interface fragment, or is a member of a union
+        // fragment). The fragment's fields apply unconditionally — process its
+        // selection set with the concrete parent so that any deeper abstract
+        // spreads also resolve against the same concrete type.
+        if (
+            ! $hasDirective
+            && $parentType instanceof ObjectType
+            && ! $isSameType
+            && $this->parentSatisfiesAbstract($parentType, $fragmentType)
+        ) {
+            $this->processSelections($fragmentDef->selectionSet, $parentType, $shape, $newVisited);
 
             return;
         }
@@ -399,6 +511,30 @@ final readonly class PayloadShapeBuilder
 
         $isOptional = $this->shouldFieldsBeOptional($parentType, $fragmentType, $hasDirective);
         $shape->merge($fragmentShape, $isOptional);
+    }
+
+    /**
+     * Is the concrete object type a runtime member of the fragment's abstract
+     * type? True when `$parentType` implements an interface fragment, or is
+     * listed in a union fragment.
+     *
+     * @throws \GraphQL\Error\InvariantViolation
+     */
+    private function parentSatisfiesAbstract(ObjectType $parentType, NamedType $fragmentType) : bool
+    {
+        if ($fragmentType instanceof InterfaceType) {
+            return $parentType->implementsInterface($fragmentType);
+        }
+
+        if ($fragmentType instanceof UnionType) {
+            foreach ($fragmentType->getTypes() as $member) {
+                if ($member->name === $parentType->name()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function shouldFieldsBeOptional(

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -666,41 +666,186 @@ final class SelectionSetPlanner
     }
 
     /**
-     * Collect and merge field selections from direct selections only
-     * Fragment spread fields must remain isolated and are NOT collected here
+     * Collect and merge field selections from direct selections, enriching the
+     * sub-selection sets of POLYMORPHIC fields that are ALSO selected by same-
+     * type fragment spreads at this level. Only directly-selected field names
+     * surface as keys — spread-only fields stay isolated to the fragment
+     * accessor — and the enrichment is restricted to interface/union-typed
+     * fields, where the recursive class's sealed-arm shape otherwise rejects
+     * the spread-contributed extras (PHPStan: "Sealed array shape does not
+     * accept array with extra key ..."). Concrete-typed fields keep their
+     * isolation because their open shapes accept extras without complaint.
+     *
+     * @throws InvariantViolation
      * @return array<string, FieldNode>
      */
     private function collectMergedFieldSelections(SelectionSetNode $selectionSet, NamedType & Type $type) : array
     {
         $fieldsByName = [];
 
-        // Collect direct field selections ONLY
-        // Fragment spread fields should NOT be collected here - they must remain isolated
-        // and only accessible through fragment accessors
         foreach ($selectionSet->selections as $selection) {
             if ($selection instanceof FieldNode) {
                 $fieldName = $selection->alias->value ?? $selection->name->value;
-
-                if ( ! isset($fieldsByName[$fieldName])) {
-                    $fieldsByName[$fieldName] = [];
-                }
-
+                $fieldsByName[$fieldName] ??= [];
                 $fieldsByName[$fieldName][] = $selection;
             }
         }
 
-        // Merge selections for fields that appear multiple times
+        if ($type instanceof HasFieldsType) {
+            $spreadContributions = null;
+
+            foreach ($fieldsByName as $fieldName => &$selections) {
+                if ($fieldName === '__typename') {
+                    continue;
+                }
+
+                if ( ! $this->fieldTypeIsPolymorphic($type, $fieldName)) {
+                    continue;
+                }
+
+                $spreadContributions ??= $this->collectSpreadContributedFieldSelections($selectionSet, $type, []);
+
+                if (isset($spreadContributions[$fieldName])) {
+                    $selections = [...$selections, ...$spreadContributions[$fieldName]];
+                }
+            }
+
+            unset($selections);
+        }
+
         $mergedFields = [];
         foreach ($fieldsByName as $fieldName => $selections) {
             if (count($selections) === 1) {
                 $mergedFields[$fieldName] = $selections[0];
             } else {
-                // Merge the selection sets of fields that appear multiple times
                 $mergedFields[$fieldName] = $this->mergeFieldNodes($selections);
             }
         }
 
         return $mergedFields;
+    }
+
+    private function fieldTypeIsPolymorphic(HasFieldsType $parent, string $fieldName) : bool
+    {
+        if ($fieldName === '__typename' || ! $parent->hasField($fieldName)) {
+            return false;
+        }
+
+        $fieldType = $parent->getField($fieldName)->getType();
+
+        while ($fieldType instanceof WrappingType) {
+            $fieldType = $fieldType->getWrappedType();
+        }
+
+        return $fieldType instanceof InterfaceType || $fieldType instanceof UnionType;
+    }
+
+    /**
+     * Walk unconditional same-type (or implementor) fragment spreads at this
+     * level and collect their direct field selections by name. Used only to
+     * enrich `collectMergedFieldSelections`' sub-selection merges — never to
+     * surface new public properties.
+     *
+     * @param array<string, true> $visitedFragments
+     * @throws InvariantViolation
+     * @return array<string, list<FieldNode>>
+     */
+    private function collectSpreadContributedFieldSelections(
+        SelectionSetNode $selectionSet,
+        NamedType & Type $parent,
+        array $visitedFragments,
+    ) : array {
+        $fieldsByName = [];
+
+        foreach ($selectionSet->selections as $selection) {
+            if ( ! $selection instanceof FragmentSpreadNode) {
+                continue;
+            }
+
+            $fragmentName = $selection->name->value;
+
+            if (isset($visitedFragments[$fragmentName])) {
+                continue;
+            }
+
+            if ( ! isset($this->fragmentDefinitions[$fragmentName])) {
+                continue;
+            }
+
+            if ($this->spreadHasConditionalDirective($selection)) {
+                continue;
+            }
+
+            $fragmentType = $this->fragmentTypes[$fragmentName];
+            $isSameType = $fragmentType->name() === $parent->name();
+            $satisfies = ! $isSameType
+                && $parent instanceof ObjectType
+                && $this->parentSatisfiesAbstract($parent, $fragmentType);
+
+            if ( ! $isSameType && ! $satisfies) {
+                continue;
+            }
+
+            $fragmentDef = $this->fragmentDefinitions[$fragmentName][0];
+            $newVisited = [
+                ...$visitedFragments,
+                $fragmentName => true,
+            ];
+
+            foreach ($fragmentDef->selectionSet->selections as $sub) {
+                if ($sub instanceof FieldNode) {
+                    $name = $sub->alias->value ?? $sub->name->value;
+                    $fieldsByName[$name] ??= [];
+                    $fieldsByName[$name][] = $sub;
+                }
+            }
+
+            $nested = $this->collectSpreadContributedFieldSelections(
+                $fragmentDef->selectionSet,
+                $parent,
+                $newVisited,
+            );
+
+            foreach ($nested as $name => $selections) {
+                $fieldsByName[$name] ??= [];
+                $fieldsByName[$name] = [...$fieldsByName[$name], ...$selections];
+            }
+        }
+
+        return $fieldsByName;
+    }
+
+    private function spreadHasConditionalDirective(FragmentSpreadNode $spread) : bool
+    {
+        foreach ($spread->directives as $directive) {
+            $name = $directive->name->value;
+
+            if ($name === 'include' || $name === 'skip') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws InvariantViolation
+     */
+    private function parentSatisfiesAbstract(ObjectType $parent, NamedType $fragmentType) : bool
+    {
+        if ($fragmentType instanceof InterfaceType) {
+            return $parent->implementsInterface($fragmentType);
+        }
+
+        if ($fragmentType instanceof UnionType) {
+            foreach ($fragmentType->getTypes() as $member) {
+                if ($member->name === $parent->name()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Planner/SelectionSetPlanner.php
+++ b/src/Planner/SelectionSetPlanner.php
@@ -597,8 +597,9 @@ final class SelectionSetPlanner
         $pathFields->addWithPrefix($context->path, $fieldName, $accessorType);
         $pathFields->merge($fragmentResult->pathFields);
 
-        // Merge inline fragment fields into parent payload as optional
-        $this->mergeInlineFragmentPayload($fragmentResult->payloadShape, $payloadShape);
+        // The parent payload already includes this variant — PayloadShapeBuilder
+        // registers it via `PayloadShape::addVariant()` while building the parent
+        // shape at the top of `planNamedTypeSelectionSet()`.
     }
 
     /**
@@ -1106,13 +1107,6 @@ final class SelectionSetPlanner
                 }
             }
         }
-    }
-
-    private function mergeInlineFragmentPayload(
-        PayloadShape $fragmentPayload,
-        PayloadShape $parentPayload,
-    ) : void {
-        $parentPayload->merge($fragmentPayload, asOptional: true);
     }
 
     // Utility methods

--- a/tests/ExplicitTypename/Generated/Query/Test/Data.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data.php
@@ -22,11 +22,13 @@ final class Data
     /**
      * @param array{
      *     'viewer': array{
-     *         '__typename': string,
-     *         'login'?: string,
+     *         '__typename': 'Application',
      *         'name': string,
-     *         'url'?: string,
-     *         ...,
+     *         'url': string,
+     *     }|array{
+     *         '__typename': 'User',
+     *         'login': string,
+     *         'name': string,
      *     },
      *     ...,
      * } $data

--- a/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
+++ b/tests/ExplicitTypename/Generated/Query/Test/Data/Viewer.php
@@ -16,25 +16,7 @@ final class Viewer
     }
 
     public ?AsApplication $asApplication {
-        get {
-            if (isset($this->asApplication)) {
-                return $this->asApplication;
-            }
-
-            if ($this->data['__typename'] !== 'Application') {
-                return $this->asApplication = null;
-            }
-
-            if (! array_key_exists('url', $this->data)) {
-                return $this->asApplication = null;
-            }
-
-            if (! array_key_exists('name', $this->data)) {
-                return $this->asApplication = null;
-            }
-
-            return $this->asApplication = new AsApplication($this->data);
-        }
+        get => $this->asApplication ??= $this->data['__typename'] === 'Application' ? new AsApplication($this->data) : null;
     }
 
     /**
@@ -50,21 +32,7 @@ final class Viewer
     }
 
     public ?UserDetails $userDetails {
-        get {
-            if (isset($this->userDetails)) {
-                return $this->userDetails;
-            }
-
-            if ($this->data['__typename'] !== 'User') {
-                return $this->userDetails = null;
-            }
-
-            if (! array_key_exists('login', $this->data)) {
-                return $this->userDetails = null;
-            }
-
-            return $this->userDetails = new UserDetails($this->data);
-        }
+        get => $this->userDetails ??= $this->data['__typename'] === 'User' ? new UserDetails($this->data) : null;
     }
 
     /**
@@ -77,11 +45,13 @@ final class Viewer
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'login'?: string,
+     *     '__typename': 'Application',
      *     'name': string,
-     *     'url'?: string,
-     *     ...,
+     *     'url': string,
+     * }|array{
+     *     '__typename': 'User',
+     *     'login': string,
+     *     'name': string,
      * } $data
      */
     public function __construct(

--- a/tests/Fragments/Generated/Query/Test/Data.php
+++ b/tests/Fragments/Generated/Query/Test/Data.php
@@ -36,11 +36,13 @@ final class Data
      *         ...,
      *     }>,
      *     'viewer': array{
-     *         '__typename': string,
-     *         'login'?: string,
+     *         '__typename': 'Application',
      *         'name': string,
-     *         'url'?: string,
-     *         ...,
+     *         'url': string,
+     *     }|array{
+     *         '__typename': 'User',
+     *         'login': string,
+     *         'name': string,
      *     },
      *     ...,
      * } $data

--- a/tests/Fragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Fragments/Generated/Query/Test/Data/Viewer.php
@@ -13,21 +13,7 @@ use Ruudk\GraphQLCodeGenerator\Fragments\Generated\Fragment\ViewerName;
 final class Viewer
 {
     public ?ApplicationDetails $applicationDetails {
-        get {
-            if (isset($this->applicationDetails)) {
-                return $this->applicationDetails;
-            }
-
-            if ($this->data['__typename'] !== 'Application') {
-                return $this->applicationDetails = null;
-            }
-
-            if (! array_key_exists('url', $this->data)) {
-                return $this->applicationDetails = null;
-            }
-
-            return $this->applicationDetails = new ApplicationDetails($this->data);
-        }
+        get => $this->applicationDetails ??= $this->data['__typename'] === 'Application' ? new ApplicationDetails($this->data) : null;
     }
 
     /**
@@ -39,21 +25,7 @@ final class Viewer
     }
 
     public ?UserDetails $userDetails {
-        get {
-            if (isset($this->userDetails)) {
-                return $this->userDetails;
-            }
-
-            if ($this->data['__typename'] !== 'User') {
-                return $this->userDetails = null;
-            }
-
-            if (! array_key_exists('login', $this->data)) {
-                return $this->userDetails = null;
-            }
-
-            return $this->userDetails = new UserDetails($this->data);
-        }
+        get => $this->userDetails ??= $this->data['__typename'] === 'User' ? new UserDetails($this->data) : null;
     }
 
     /**
@@ -78,11 +50,13 @@ final class Viewer
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'login'?: string,
+     *     '__typename': 'Application',
      *     'name': string,
-     *     'url'?: string,
-     *     ...,
+     *     'url': string,
+     * }|array{
+     *     '__typename': 'User',
+     *     'login': string,
+     *     'name': string,
      * } $data
      */
     public function __construct(

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data.php
@@ -26,11 +26,13 @@ final class Data
     /**
      * @param array{
      *     'things': list<array{
-     *         '__typename': string,
+     *         '__typename': 'VariantA',
      *         'id': string,
-     *         'realFieldA'?: string,
-     *         'realFieldB'?: string,
-     *         ...,
+     *         'realFieldA': string,
+     *     }|array{
+     *         '__typename': 'VariantB',
+     *         'id': string,
+     *         'realFieldB': string,
      *     }>,
      *     ...,
      * } $data

--- a/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
+++ b/tests/HooksInUnionVariant/Generated/Query/Test/Data/Thing.php
@@ -17,25 +17,7 @@ final class Thing
     }
 
     public ?AsVariantA $asVariantA {
-        get {
-            if (isset($this->asVariantA)) {
-                return $this->asVariantA;
-            }
-
-            if ($this->data['__typename'] !== 'VariantA') {
-                return $this->asVariantA = null;
-            }
-
-            if (! array_key_exists('id', $this->data)) {
-                return $this->asVariantA = null;
-            }
-
-            if (! array_key_exists('realFieldA', $this->data)) {
-                return $this->asVariantA = null;
-            }
-
-            return $this->asVariantA = new AsVariantA($this->data, $this->hooks);
-        }
+        get => $this->asVariantA ??= $this->data['__typename'] === 'VariantA' ? new AsVariantA($this->data, $this->hooks) : null;
     }
 
     /**
@@ -47,21 +29,7 @@ final class Thing
     }
 
     public ?AsVariantB $asVariantB {
-        get {
-            if (isset($this->asVariantB)) {
-                return $this->asVariantB;
-            }
-
-            if ($this->data['__typename'] !== 'VariantB') {
-                return $this->asVariantB = null;
-            }
-
-            if (! array_key_exists('realFieldB', $this->data)) {
-                return $this->asVariantB = null;
-            }
-
-            return $this->asVariantB = new AsVariantB($this->data);
-        }
+        get => $this->asVariantB ??= $this->data['__typename'] === 'VariantB' ? new AsVariantB($this->data) : null;
     }
 
     /**
@@ -78,11 +46,13 @@ final class Thing
 
     /**
      * @param array{
-     *     '__typename': string,
+     *     '__typename': 'VariantA',
      *     'id': string,
-     *     'realFieldA'?: string,
-     *     'realFieldB'?: string,
-     *     ...,
+     *     'realFieldA': string,
+     * }|array{
+     *     '__typename': 'VariantB',
+     *     'id': string,
+     *     'realFieldB': string,
      * } $data
      * @param array{
      *     'findUserById': FindUserByIdHook,

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data.php
@@ -25,11 +25,14 @@ final class Data
     /**
      * @param array{
      *     'addCountry': array{
-     *         '__typename': string,
-     *         'code'?: string,
-     *         'id'?: string,
-     *         'name'?: string,
-     *         ...,
+     *         '__typename': 'Country',
+     *         'id': string,
+     *         'name': string,
+     *     }|array{
+     *         '__typename': 'SupportedCountryError',
+     *     }|array{
+     *         '__typename': 'UnsupportedCountryError',
+     *         'code': string,
      *     },
      *     ...,
      * } $data

--- a/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
+++ b/tests/InlineFragmentTypename/Generated/Mutation/Test/Data/AddCountry.php
@@ -13,25 +13,7 @@ use Ruudk\GraphQLCodeGenerator\InlineFragmentTypename\Generated\Mutation\Test\Da
 final class AddCountry
 {
     public ?AsCountry $asCountry {
-        get {
-            if (isset($this->asCountry)) {
-                return $this->asCountry;
-            }
-
-            if ($this->data['__typename'] !== 'Country') {
-                return $this->asCountry = null;
-            }
-
-            if (! array_key_exists('id', $this->data)) {
-                return $this->asCountry = null;
-            }
-
-            if (! array_key_exists('name', $this->data)) {
-                return $this->asCountry = null;
-            }
-
-            return $this->asCountry = new AsCountry($this->data);
-        }
+        get => $this->asCountry ??= $this->data['__typename'] === 'Country' ? new AsCountry($this->data) : null;
     }
 
     /**
@@ -55,21 +37,7 @@ final class AddCountry
     }
 
     public ?AsUnsupportedCountryError $asUnsupportedCountryError {
-        get {
-            if (isset($this->asUnsupportedCountryError)) {
-                return $this->asUnsupportedCountryError;
-            }
-
-            if ($this->data['__typename'] !== 'UnsupportedCountryError') {
-                return $this->asUnsupportedCountryError = null;
-            }
-
-            if (! array_key_exists('code', $this->data)) {
-                return $this->asUnsupportedCountryError = null;
-            }
-
-            return $this->asUnsupportedCountryError = new AsUnsupportedCountryError($this->data);
-        }
+        get => $this->asUnsupportedCountryError ??= $this->data['__typename'] === 'UnsupportedCountryError' ? new AsUnsupportedCountryError($this->data) : null;
     }
 
     /**
@@ -82,11 +50,14 @@ final class AddCountry
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'code'?: string,
-     *     'id'?: string,
-     *     'name'?: string,
-     *     ...,
+     *     '__typename': 'Country',
+     *     'id': string,
+     *     'name': string,
+     * }|array{
+     *     '__typename': 'SupportedCountryError',
+     * }|array{
+     *     '__typename': 'UnsupportedCountryError',
+     *     'code': string,
      * } $data
      */
     public function __construct(

--- a/tests/InlineFragments/Generated/Query/Test/Data.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data.php
@@ -36,11 +36,13 @@ final class Data
      *         ...,
      *     }>,
      *     'viewer': array{
-     *         '__typename': string,
-     *         'login'?: string,
+     *         '__typename': 'Application',
      *         'name': string,
-     *         'url'?: string,
-     *         ...,
+     *         'url': string,
+     *     }|array{
+     *         '__typename': 'User',
+     *         'login': string,
+     *         'name': string,
      *     },
      *     ...,
      * } $data

--- a/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
+++ b/tests/InlineFragments/Generated/Query/Test/Data/Viewer.php
@@ -12,21 +12,7 @@ use Ruudk\GraphQLCodeGenerator\InlineFragments\Generated\Query\Test\Data\Viewer\
 final class Viewer
 {
     public ?AsApplication $asApplication {
-        get {
-            if (isset($this->asApplication)) {
-                return $this->asApplication;
-            }
-
-            if ($this->data['__typename'] !== 'Application') {
-                return $this->asApplication = null;
-            }
-
-            if (! array_key_exists('url', $this->data)) {
-                return $this->asApplication = null;
-            }
-
-            return $this->asApplication = new AsApplication($this->data);
-        }
+        get => $this->asApplication ??= $this->data['__typename'] === 'Application' ? new AsApplication($this->data) : null;
     }
 
     /**
@@ -38,21 +24,7 @@ final class Viewer
     }
 
     public ?AsUser $asUser {
-        get {
-            if (isset($this->asUser)) {
-                return $this->asUser;
-            }
-
-            if ($this->data['__typename'] !== 'User') {
-                return $this->asUser = null;
-            }
-
-            if (! array_key_exists('login', $this->data)) {
-                return $this->asUser = null;
-            }
-
-            return $this->asUser = new AsUser($this->data);
-        }
+        get => $this->asUser ??= $this->data['__typename'] === 'User' ? new AsUser($this->data) : null;
     }
 
     /**
@@ -69,11 +41,13 @@ final class Viewer
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'login'?: string,
+     *     '__typename': 'Application',
      *     'name': string,
-     *     'url'?: string,
-     *     ...,
+     *     'url': string,
+     * }|array{
+     *     '__typename': 'User',
+     *     'login': string,
+     *     'name': string,
      * } $data
      */
     public function __construct(

--- a/tests/Optimization/Generated/Query/Test/Data.php
+++ b/tests/Optimization/Generated/Query/Test/Data.php
@@ -36,13 +36,17 @@ final class Data
      *         ...,
      *     }>,
      *     'viewer': array{
-     *         '__typename': string,
+     *         '__typename': 'Application',
      *         'id': string,
      *         'idAlias': string,
-     *         'login'?: string,
      *         'name': string,
-     *         'url'?: string,
-     *         ...,
+     *         'url': string,
+     *     }|array{
+     *         '__typename': 'User',
+     *         'id': string,
+     *         'idAlias': string,
+     *         'login': string,
+     *         'name': string,
      *     },
      *     ...,
      * } $data

--- a/tests/Optimization/Generated/Query/Test/Data/Viewer.php
+++ b/tests/Optimization/Generated/Query/Test/Data/Viewer.php
@@ -12,25 +12,7 @@ use Ruudk\GraphQLCodeGenerator\Optimization\Generated\Query\Test\Data\Viewer\AsU
 final class Viewer
 {
     public ?AppUrl $appUrl {
-        get {
-            if (isset($this->appUrl)) {
-                return $this->appUrl;
-            }
-
-            if ($this->data['__typename'] !== 'Application') {
-                return $this->appUrl = null;
-            }
-
-            if (! array_key_exists('url', $this->data)) {
-                return $this->appUrl = null;
-            }
-
-            if (! array_key_exists('name', $this->data)) {
-                return $this->appUrl = null;
-            }
-
-            return $this->appUrl = new AppUrl($this->data);
-        }
+        get => $this->appUrl ??= $this->data['__typename'] === 'Application' ? new AppUrl($this->data) : null;
     }
 
     /**
@@ -42,25 +24,7 @@ final class Viewer
     }
 
     public ?AsUser $asUser {
-        get {
-            if (isset($this->asUser)) {
-                return $this->asUser;
-            }
-
-            if ($this->data['__typename'] !== 'User') {
-                return $this->asUser = null;
-            }
-
-            if (! array_key_exists('login', $this->data)) {
-                return $this->asUser = null;
-            }
-
-            if (! array_key_exists('name', $this->data)) {
-                return $this->asUser = null;
-            }
-
-            return $this->asUser = new AsUser($this->data);
-        }
+        get => $this->asUser ??= $this->data['__typename'] === 'User' ? new AsUser($this->data) : null;
     }
 
     /**
@@ -85,13 +49,17 @@ final class Viewer
 
     /**
      * @param array{
-     *     '__typename': string,
+     *     '__typename': 'Application',
      *     'id': string,
      *     'idAlias': string,
-     *     'login'?: string,
      *     'name': string,
-     *     'url'?: string,
-     *     ...,
+     *     'url': string,
+     * }|array{
+     *     '__typename': 'User',
+     *     'id': string,
+     *     'idAlias': string,
+     *     'login': string,
+     *     'name': string,
      * } $data
      */
     public function __construct(

--- a/tests/Planner/PayloadShapeBuilderTest.php
+++ b/tests/Planner/PayloadShapeBuilderTest.php
@@ -368,11 +368,15 @@ final class PayloadShapeBuilderTest extends TestCase
         self::assertSame(
             <<<'PHPDOC'
                 array{
-                    'address'?: null|string,
-                    'email'?: string,
+                    '__typename': 'AdminViewer',
+                    'email': string,
                     'id': string,
-                    'role'?: string,
-                    ...,
+                    'role': string,
+                }|array{
+                    '__typename': 'UserViewer',
+                    'address': null|string,
+                    'email': string,
+                    'id': string,
                 }
                 PHPDOC,
             TypeDumper::dump($shape->toArrayShape()),
@@ -639,14 +643,18 @@ final class PayloadShapeBuilderTest extends TestCase
             <<<'PHPDOC'
                 array{
                     'search': list<array{
-                        'id'?: string,
-                        'transfers'?: list<array{
+                        '__typename': 'Customer',
+                    }|array{
+                        '__typename': 'Transaction',
+                        'id': string,
+                        'transfers': list<array{
                             'canBeCollected': bool,
                             'id': string,
                             'state': string,
                             ...,
                         }>,
-                        ...,
+                    }|array{
+                        '__typename': 'User',
                     }>,
                     ...,
                 }
@@ -782,10 +790,13 @@ final class PayloadShapeBuilderTest extends TestCase
             <<<'PHPDOC'
                 array{
                     'search': list<array{
-                        'email'?: null|string,
-                        'id'?: string,
-                        'name'?: string,
-                        'transfers'?: list<array{
+                        '__typename': 'Customer',
+                        'id': string,
+                        'name': string,
+                    }|array{
+                        '__typename': 'Transaction',
+                        'id': string,
+                        'transfers': list<array{
                             'canBeCollected': bool,
                             'createdAt': string,
                             'customer': null|array{
@@ -801,7 +812,11 @@ final class PayloadShapeBuilderTest extends TestCase
                             }>,
                             ...,
                         }>,
-                        ...,
+                    }|array{
+                        '__typename': 'User',
+                        'email': null|string,
+                        'id': string,
+                        'name': string,
                     }>,
                     'transaction': null|array{
                         'id': string,
@@ -1195,12 +1210,13 @@ final class PayloadShapeBuilderTest extends TestCase
                 array{
                     'id': string,
                     'search': list<array{
-                        'createdAt'?: scalar,
-                        'email'?: null|string,
-                        'id'?: string,
-                        'lastSeen'?: null|scalar,
-                        'name'?: string,
-                        'transfers'?: list<array{
+                        '__typename': 'Customer',
+                        'id': string,
+                        'name': string,
+                    }|array{
+                        '__typename': 'Transaction',
+                        'id': string,
+                        'transfers': list<array{
                             'canBeCollected': bool,
                             'customer': null|array{
                                 'id': string,
@@ -1210,7 +1226,13 @@ final class PayloadShapeBuilderTest extends TestCase
                             'state': string,
                             ...,
                         }>,
-                        ...,
+                    }|array{
+                        '__typename': 'User',
+                        'createdAt': scalar,
+                        'email': null|string,
+                        'id': string,
+                        'lastSeen': null|scalar,
+                        'name': string,
                     }>,
                     'user': null|array{
                         'email': null|string,
@@ -1227,11 +1249,15 @@ final class PayloadShapeBuilderTest extends TestCase
                         ...,
                     },
                     'viewer': null|array{
-                        'address'?: null|string,
-                        'email'?: string,
+                        '__typename': 'AdminViewer',
+                        'email': string,
                         'id': string,
-                        'role'?: string,
-                        ...,
+                        'role': string,
+                    }|array{
+                        '__typename': 'UserViewer',
+                        'address': null|string,
+                        'email': string,
+                        'id': string,
                     },
                     ...,
                 }
@@ -1281,16 +1307,30 @@ final class PayloadShapeBuilderTest extends TestCase
             <<<'PHPDOC'
                 array{
                     'actors': list<array{
-                        'createdAt'?: scalar,
-                        'department'?: null|string,
-                        'email'?: string,
-                        'firstName'?: string,
+                        '__typename': 'Developer',
+                        'createdAt': scalar,
+                        'department': null|string,
+                        'firstName': string,
                         'id': string,
-                        'languages'?: list<string>,
-                        'lastName'?: string,
-                        'role'?: string,
-                        'teamSize'?: int,
-                        ...,
+                        'languages': list<string>,
+                        'lastName': string,
+                        'role': string,
+                    }|array{
+                        '__typename': 'Manager',
+                        'createdAt': scalar,
+                        'department': null|string,
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
+                        'role': string,
+                        'teamSize': int,
+                    }|array{
+                        '__typename': 'RegularUser',
+                        'createdAt': scalar,
+                        'email': string,
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
                     }>,
                     ...,
                 }
@@ -1369,21 +1409,37 @@ final class PayloadShapeBuilderTest extends TestCase
             ),
             $queryType,
         );
-        // All fields should be optional since they're type-specific
+        // Each concrete type gets its own sealed arm with the fields its
+        // ancestry contributes — interfaces in the fragment chain widen the
+        // arm rather than introducing arms of their own.
         self::assertSame(
             <<<'PHPDOC'
                 array{
                     'actors': list<array{
-                        'createdAt'?: scalar,
-                        'department'?: null|string,
-                        'email'?: string,
-                        'firstName'?: string,
-                        'id'?: string,
-                        'languages'?: list<string>,
-                        'lastName'?: string,
-                        'role'?: string,
-                        'teamSize'?: int,
-                        ...,
+                        '__typename': 'Developer',
+                        'createdAt': scalar,
+                        'department': null|string,
+                        'firstName': string,
+                        'id': string,
+                        'languages': list<string>,
+                        'lastName': string,
+                        'role': string,
+                    }|array{
+                        '__typename': 'Manager',
+                        'createdAt': scalar,
+                        'department': null|string,
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
+                        'role': string,
+                        'teamSize': int,
+                    }|array{
+                        '__typename': 'RegularUser',
+                        'createdAt': scalar,
+                        'email': string,
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
                     }>,
                     ...,
                 }
@@ -1424,13 +1480,24 @@ final class PayloadShapeBuilderTest extends TestCase
             <<<'PHPDOC'
                 array{
                     'actors': list<array{
-                        'department'?: null|string,
-                        'firstName'?: string,
+                        '__typename': 'Developer',
+                        'firstName': string,
                         'id': string,
-                        'lastName'?: string,
-                        'role'?: string,
-                        'teamSize'?: int,
-                        ...,
+                        'lastName': string,
+                        'role': string,
+                    }|array{
+                        '__typename': 'Manager',
+                        'department': null|string,
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
+                        'role': string,
+                        'teamSize': int,
+                    }|array{
+                        '__typename': 'RegularUser',
+                        'firstName': string,
+                        'id': string,
+                        'lastName': string,
                     }>,
                     ...,
                 }
@@ -1508,23 +1575,37 @@ final class PayloadShapeBuilderTest extends TestCase
             ),
             $queryType,
         );
-        // Fields with directives should be optional
-        // __typename is always present
+        // Fields contributed by a `@include`/`@skip` fragment are optional in
+        // every arm that receives them; fields selected directly inside an
+        // unconditional inline fragment stay required for that arm.
         self::assertSame(
             <<<'PHPDOC'
                 array{
                     'actors': list<array{
-                        '__typename': string,
+                        '__typename': 'Developer',
                         'createdAt'?: scalar,
                         'department'?: null|string,
-                        'email'?: string,
                         'firstName'?: string,
                         'id'?: string,
                         'languages'?: list<string>,
                         'lastName'?: string,
                         'role'?: string,
+                    }|array{
+                        '__typename': 'Manager',
+                        'createdAt'?: scalar,
+                        'department'?: null|string,
+                        'firstName'?: string,
+                        'id'?: string,
+                        'lastName'?: string,
+                        'role'?: string,
                         'teamSize'?: int,
-                        ...,
+                    }|array{
+                        '__typename': 'RegularUser',
+                        'createdAt'?: scalar,
+                        'email': string,
+                        'firstName'?: string,
+                        'id'?: string,
+                        'lastName'?: string,
                     }>,
                     ...,
                 }

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data.php
@@ -27,13 +27,14 @@ final class Data
     /**
      * @param array{
      *     'order': array{
-     *         '__typename': string,
-     *         'fxFee'?: null|array{
+     *         '__typename': 'MarketPlaceOrderItem',
+     *         'fxFee': null|array{
      *             '__typename': string,
      *             ...,
      *         },
-     *         'id'?: string,
-     *         ...,
+     *         'id': string,
+     *     }|array{
+     *         '__typename': 'OtherOrderItem',
      *     },
      *     'supportedCountry': array{
      *         'error': null|array{

--- a/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
+++ b/tests/QueryObjectTypename/Generated/Query/Test/Data/Order.php
@@ -11,25 +11,7 @@ use Ruudk\GraphQLCodeGenerator\QueryObjectTypename\Generated\Query\Test\Data\Ord
 final class Order
 {
     public ?AsMarketPlaceOrderItem $asMarketPlaceOrderItem {
-        get {
-            if (isset($this->asMarketPlaceOrderItem)) {
-                return $this->asMarketPlaceOrderItem;
-            }
-
-            if ($this->data['__typename'] !== 'MarketPlaceOrderItem') {
-                return $this->asMarketPlaceOrderItem = null;
-            }
-
-            if (! array_key_exists('id', $this->data)) {
-                return $this->asMarketPlaceOrderItem = null;
-            }
-
-            if (! array_key_exists('fxFee', $this->data)) {
-                return $this->asMarketPlaceOrderItem = null;
-            }
-
-            return $this->asMarketPlaceOrderItem = new AsMarketPlaceOrderItem($this->data);
-        }
+        get => $this->asMarketPlaceOrderItem ??= $this->data['__typename'] === 'MarketPlaceOrderItem' ? new AsMarketPlaceOrderItem($this->data) : null;
     }
 
     /**
@@ -42,13 +24,14 @@ final class Order
 
     /**
      * @param array{
-     *     '__typename': string,
-     *     'fxFee'?: null|array{
+     *     '__typename': 'MarketPlaceOrderItem',
+     *     'fxFee': null|array{
      *         '__typename': string,
      *         ...,
      *     },
-     *     'id'?: string,
-     *     ...,
+     *     'id': string,
+     * }|array{
+     *     '__typename': 'OtherOrderItem',
      * } $data
      */
     public function __construct(

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Fragment/ContainerBase.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Fragment/ContainerBase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Fragment;
+
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Fragment\ContainerBase\Item;
+
+// This file was automatically generated and should not be edited.
+
+final class ContainerBase
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public Item $item {
+        get => $this->item ??= new Item($this->data['item']);
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'item': array{
+     *         'id': string,
+     *         ...,
+     *     },
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Fragment/ContainerBase/Item.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Fragment/ContainerBase/Item.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Fragment\ContainerBase;
+
+// This file was automatically generated and should not be edited.
+
+final class Item
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public Container $container {
+        get => $this->container ??= new Container($this->data['container']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'container': array{
+     *         'id': string,
+     *         'item': array{
+     *             '__typename': 'VariantA',
+     *             'id': string,
+     *             'valueA': string,
+     *         }|array{
+     *             '__typename': 'VariantB',
+     *             'id': string,
+     *             'valueB': string,
+     *         },
+     *         ...,
+     *     },
+     *     ...,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data;
+
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Fragment\ContainerBase;
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container\Item;
+
+// This file was automatically generated and should not be edited.
+
+final class Container
+{
+    public ContainerBase $containerBase {
+        get => $this->containerBase ??= new ContainerBase($this->data);
+    }
+
+    public Item $item {
+        get => $this->item ??= new Item($this->data['item']);
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'item': array{
+     *         '__typename': 'VariantA',
+     *         'id': string,
+     *         'valueA': string,
+     *     }|array{
+     *         '__typename': 'VariantB',
+     *         'id': string,
+     *         'valueB': string,
+     *     },
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container;
+
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container\Item\AsVariantA;
+use Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container\Item\AsVariantB;
+
+// This file was automatically generated and should not be edited.
+
+final class Item
+{
+    public ?AsVariantA $asVariantA {
+        get => $this->asVariantA ??= $this->data['__typename'] === 'VariantA' ? new AsVariantA($this->data) : null;
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asVariantA
+     */
+    public bool $isVariantA {
+        get => $this->isVariantA ??= $this->data['__typename'] === 'VariantA';
+    }
+
+    public ?AsVariantB $asVariantB {
+        get => $this->asVariantB ??= $this->data['__typename'] === 'VariantB' ? new AsVariantB($this->data) : null;
+    }
+
+    /**
+     * @api
+     * @phpstan-assert-if-true !null $this->asVariantB
+     */
+    public bool $isVariantB {
+        get => $this->isVariantB ??= $this->data['__typename'] === 'VariantB';
+    }
+
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'VariantA',
+     *     'id': string,
+     *     'valueA': string,
+     * }|array{
+     *     '__typename': 'VariantB',
+     *     'id': string,
+     *     'valueB': string,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item/AsVariantA.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item/AsVariantA.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container\Item;
+
+// This file was automatically generated and should not be edited.
+
+final class AsVariantA
+{
+    public string $valueA {
+        get => $this->valueA ??= $this->data['valueA'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'VariantA',
+     *     'valueA': string,
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item/AsVariantB.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Data/Container/Item/AsVariantB.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test\Data\Container\Item;
+
+// This file was automatically generated and should not be edited.
+
+final class AsVariantB
+{
+    public string $valueB {
+        get => $this->valueB ??= $this->data['valueB'];
+    }
+
+    /**
+     * @param array{
+     *     '__typename': 'VariantB',
+     *     'valueB': string,
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Error.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/Error.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/TestQuery.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Generated/Query/Test/TestQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField\Generated\Query\Test;
+
+use Ruudk\GraphQLCodeGenerator\TestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class TestQuery {
+    public const string OPERATION_NAME = 'Test';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Test {
+          container {
+            ...ContainerBase
+            item {
+              __typename
+              ... on VariantA {
+                valueA
+              }
+              ... on VariantB {
+                valueB
+              }
+            }
+          }
+        }
+        
+        fragment ContainerBase on Container {
+          id
+          item {
+            id
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private TestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Schema.graphql
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Schema.graphql
@@ -1,0 +1,22 @@
+type Query {
+    container: Container!
+}
+
+type Container {
+    id: ID!
+    item: Item!
+}
+
+interface Item {
+    id: ID!
+}
+
+type VariantA implements Item {
+    id: ID!
+    valueA: String!
+}
+
+type VariantB implements Item {
+    id: ID!
+    valueB: String!
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/SpreadAddsFieldsToPolymorphicFieldTest.php
+++ b/tests/SpreadAddsFieldsToPolymorphicField/SpreadAddsFieldsToPolymorphicFieldTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\SpreadAddsFieldsToPolymorphicField;
+
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+
+/**
+ * Regression test for the case where a fragment spread at the parent's
+ * selection set adds fields at the same path as a polymorphic field that
+ * also has inline-fragment selections.
+ *
+ * The parent's payload shape correctly merges both selections, so each
+ * polymorphic arm carries the spread-contributed fields (here: `id`).
+ * The polymorphic-field subclass must reflect the same shape — otherwise
+ * `new Item($this->data['item'])` is rejected by PHPStan because the
+ * sealed arms don't accept the extra `id` key.
+ */
+final class SpreadAddsFieldsToPolymorphicFieldTest extends GraphQLTestCase
+{
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+}

--- a/tests/SpreadAddsFieldsToPolymorphicField/Test.graphql
+++ b/tests/SpreadAddsFieldsToPolymorphicField/Test.graphql
@@ -1,0 +1,20 @@
+query Test {
+    container {
+        ...ContainerBase
+        item {
+            ... on VariantA {
+                valueA
+            }
+            ... on VariantB {
+                valueB
+            }
+        }
+    }
+}
+
+fragment ContainerBase on Container {
+    id
+    item {
+        id
+    }
+}


### PR DESCRIPTION
## Summary

Replace blended `array{name: string, 'login'?: string, 'url'?: string, ...}` payload shapes for polymorphic GraphQL selections with `array{__typename: 'User', name: string, login: string} | array{__typename: 'Application', name: string, url: string}` — a union of sealed arms, one per concrete type, discriminated by `__typename`.

### Before
```php
/**
 * @param array{
 *     '__typename': string,
 *     'login'?: string,
 *     'name': string,
 *     'url'?: string,
 *     ...,
 * } $data
 */
```

### After
```php
/**
 * @param array{
 *     '__typename': 'Application',
 *     'name': string,
 *     'url': string,
 * }|array{
 *     '__typename': 'User',
 *     'login': string,
 *     'name': string,
 * } $data
 */
```

Variant getters lose their `array_key_exists` guards — PHPStan narrows on `__typename` literal alone, so the variant subclass's required fields are provably present.

## How the planner produces the union

- **Concrete-type fragments** (`... on User { login }`) add a variant arm keyed by the concrete type name.
- **Abstract-type fragments** (`... on Person { firstName, lastName }` where `Person` is an interface) distribute their fields to every concrete implementor. Abstract type names never appear as arms — `__typename` only holds a concrete object type at runtime.
- **Schema enumeration** — even when only one fragment is written, every concrete type in the parent's union/interface is emitted as an arm (empty body for the unwritten ones). This stops `__typename === 'X'` from becoming `always-true` on single-fragment queries against multi-member abstract types.
- **Nested variants** — `... on Employee { role }` inside `... on Person` contributes `role` to the `Developer` / `Manager` arms (both implement `Employee`) but not to `RegularUser`. `PayloadShape::addVariant()` collapses matching nested variants into the destination so this resolves correctly.
- **Conditional fragments** (`@include` / `@skip`) demote their contributed variant fields to optional via `withFieldsOptional()`.

## Trade-off you signed off on

No explicit "fallback arm" with a wide `__typename: string`. If the server returns a concrete `__typename` the client didn't write a fragment for *and* you didn't include that type in the schema, the type system says "impossible" — but runtime stays safe because the variant getters still return `null` on mismatched `__typename`. For closed `union` schema members this is exact; for open `interface` implementors it's a small fiction.

## Test plan

- [x] All 179 unit tests pass.
- [x] PHPStan max passes (no errors).
- [x] All 39 generated fixtures (`tests/*/Generated/`, `examples/Generated/`) regenerated and round-trip via `--ensure-sync`.
- [x] `tests/Planner/PayloadShapeBuilderTest.php` expectations updated for the 8 polymorphic-selection tests.
- [x] Hand-checked `InlineFragments`, `InlineFragmentTypename`, `QueryObjectTypename`, `HooksInUnionVariant`, `Optimization`, `ExplicitTypename`, `Fragments` generated outputs.

https://claude.ai/code/session_01WwMs8ZS9JBdXD6ZzwREpzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwMs8ZS9JBdXD6ZzwREpzF)_