### PR TITLE
Add operation arguments to inject extra params into generated operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ enum SearchType: string
 - **Custom `@indexBy` directive** for O(1) lookups instead of O(n) searching
 - **Custom `@throwWhenNull` directive** - drop nullability per-field and throw a typed exception when the server returns null
 - **Custom `@hook` directive** - enrich responses with local data resolved lazily at access time
+- **Operation arguments** via `withOperationArgument()` - inject extra typed parameters (e.g. an actor) into `execute()` and forward them to your client, optionally gated by a custom directive
 - **Fragment dependency injection** - automatically includes required fragments
 - **Automatic query optimization** - merges fragments, simplifies inline fragments
 
@@ -1022,6 +1023,135 @@ Notes:
   twice.
 - Omitting `batched` (or `batched: false`) keeps the existing per-instance behaviour — this is
   not a breaking change. Legacy and batched hooks can be mixed in one query.
+
+### 🎭 Inject Extra Arguments with `withOperationArgument()`
+
+Sometimes a generated operation needs to forward something to your client that is *not* a GraphQL
+variable — an actor, a tenant, a correlation id, an idempotency key. `withOperationArgument()`
+prepends an extra typed parameter to the generated `execute()` / `executeOrThrow()` methods and
+forwards it positionally to your client's `graphql()` call (right after the operation name):
+
+```php
+use Symfony\Component\TypeInfo\Type;
+
+Config::create(/* ... */)
+    ->withOperationArgument(
+        name: 'actor',
+        type: Type::object(Actor::class),
+        directive: 'requiresActor', // opt-in: only operations tagged @requiresActor
+    );
+```
+
+- **Opt-in via a directive** — pass `directive: 'requiresActor'` and only operations carrying
+  `@requiresActor` receive the extra parameter. The directive is local to your operation: it is
+  registered automatically (so validation passes) and stripped from the query sent to the server.
+- **Apply to every operation** — omit `directive` and the parameter is injected into *all*
+  operations.
+- **Restrict by operation type** — pass `operations: ['mutation']` (or `['query']`) to limit which
+  operation types the argument may target. The default is an empty array, which allows any type.
+- Call `withOperationArgument()` multiple times to inject more than one argument; they are emitted
+  in registration order, before the GraphQL variables.
+
+<!-- source: tests/OperationArgument/CreateThing.graphql -->
+```graphql
+mutation CreateThing($name: String!) @requiresActor {
+    createThing(name: $name) {
+        id
+        name
+    }
+}
+```
+
+**Generated code** — `Actor $actor` leads the signature and is forwarded to `graphql()`, while the
+`@requiresActor` directive is gone from `OPERATION_DEFINITION`:
+
+<!-- source: tests/OperationArgument/Generated/Mutation/CreateThing/CreateThingMutation.php -->
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing;
+
+use Ruudk\GraphQLCodeGenerator\OperationArgument\Actor;
+use Ruudk\GraphQLCodeGenerator\OperationArgument\ActorTestClient;
+use Stringable;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class CreateThingMutation {
+    public const string OPERATION_NAME = 'CreateThing';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        mutation CreateThing($name: String!) {
+          createThing(name: $name) {
+            id
+            name
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private ActorTestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute(
+        Actor $actor,
+        Stringable|string $name,
+    ) : Data {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+                'name' => (string) $name,
+            ],
+            self::OPERATION_NAME,
+            actor: $actor,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+
+    /**
+     * @api
+     * @throws CreateThingMutationFailedException
+     */
+    public function executeOrThrow(
+        Actor $actor,
+        Stringable|string $name,
+    ) : Data {
+        $data = $this->execute(
+            $actor,
+            $name,
+        );
+
+        if ($data->errors !== []) {
+            throw new CreateThingMutationFailedException($data);
+        }
+
+        return $data;
+    }
+}
+```
+
+Your client's `graphql()` method receives the extra argument(s) positionally, so add them to its
+signature (make them optional if only some operations forward them):
+
+```php
+public function graphql(
+    string $query,
+    array $variables = [],
+    ?string $operationName = null,
+    ?Actor $actor = null,
+) : array {
+    // forward $actor to the transport — e.g. as a header
+}
+```
 
 ## Requirements
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -32,6 +32,7 @@ final readonly class Config
      * @param list<string> $inlineProcessingDirectories
      * @param list<string> $twigProcessingDirectories
      * @param array<string, HookDefinition> $hooks
+     * @param list<OperationArgument> $operationArguments
      */
     private function __construct(
         public Schema | string $schema,
@@ -65,6 +66,7 @@ final readonly class Config
         public bool $formatOperationFiles = false,
         public array $hooks = [],
         public bool $symfonyAutowireHooks = false,
+        public array $operationArguments = [],
     ) {}
 
     public static function create(
@@ -369,6 +371,48 @@ final readonly class Config
 
         return clone ($this, [
             'hooks' => $hooks,
+        ]);
+    }
+
+    /**
+     * Register an extra parameter to inject into generated operation methods.
+     *
+     * The parameter is prepended to `execute()`/`executeOrThrow()` and forwarded
+     * positionally to the client's `graphql()` call (after the operation name).
+     *
+     * When `$directive` is given, the parameter only applies to operations carrying
+     * that directive (e.g. `mutation Foo @requiresActor`). When `$directive` is null,
+     * it applies to every operation whose type is listed in `$operations`.
+     *
+     * `$operations` restricts which operation types the argument may target. Leave it
+     * empty (the default) to allow any operation type.
+     *
+     * @param list<'query'|'mutation'> $operations
+     * @throws \Webmozart\Assert\InvalidArgumentException
+     */
+    public function withOperationArgument(
+        string $name,
+        Type $type,
+        ?string $directive = null,
+        array $operations = [],
+    ) : self {
+        Assert::regex($name, '/^[a-zA-Z_][a-zA-Z0-9_]*$/', sprintf(
+            'Operation argument name "%s" must be a valid PHP identifier.',
+            $name,
+        ));
+
+        if ($directive !== null) {
+            Assert::regex($directive, '/^[a-zA-Z_][a-zA-Z0-9_]*$/', sprintf(
+                'Operation argument directive "%s" must be a valid GraphQL directive name.',
+                $directive,
+            ));
+        }
+
+        $operationArguments = $this->operationArguments;
+        $operationArguments[] = new OperationArgument($name, $type, $directive, $operations);
+
+        return clone ($this, [
+            'operationArguments' => $operationArguments,
         ]);
     }
 

--- a/src/Config/OperationArgument.php
+++ b/src/Config/OperationArgument.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Config;
+
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * An extra, non-GraphQL parameter injected into a generated operation's
+ * execute()/executeOrThrow() methods and forwarded positionally to the
+ * client's graphql() call.
+ */
+final readonly class OperationArgument
+{
+    /**
+     * @param null|string $directive When set, the argument only applies to operations carrying this directive.
+     *                               When null, it applies to every operation whose type is in $operations.
+     * @param list<'query'|'mutation'> $operations The operation types this argument may target.
+     */
+    public function __construct(
+        public string $name,
+        public Type $type,
+        public ?string $directive,
+        public array $operations,
+    ) {}
+}

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -14,6 +14,7 @@ use Ruudk\GraphQLCodeGenerator\Config\ConfigLoader;
 use Ruudk\GraphQLCodeGenerator\Executor\PlanExecutor;
 use Ruudk\GraphQLCodeGenerator\GraphQL\HookDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\GraphQL\IndexByDirectiveSchemaExtender;
+use Ruudk\GraphQLCodeGenerator\GraphQL\OperationArgumentDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\GraphQL\ThrowWhenNullDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\Planner;
 use SebastianBergmann\Diff\Differ;
@@ -125,6 +126,10 @@ final class GenerateCommand
 
                     if ($configItem->throwWhenNullDirective) {
                         $schema = ThrowWhenNullDirectiveSchemaExtender::extend($schema);
+                    }
+
+                    if ($configItem->operationArguments !== []) {
+                        $schema = OperationArgumentDirectiveSchemaExtender::extend($schema, $configItem->operationArguments);
                     }
 
                     $this->filesystem->dumpFile(

--- a/src/DirectiveProcessor.php
+++ b/src/DirectiveProcessor.php
@@ -60,6 +60,20 @@ final class DirectiveProcessor
     }
 
     /**
+     * @param NodeList<DirectiveNode> $directives
+     */
+    public function hasDirective(NodeList $directives, string $name) : bool
+    {
+        foreach ($directives as $directive) {
+            if ($directive->name->value === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Extract the @hook directive's `name` and `input` arguments.
      *
      * @param NodeList<DirectiveNode> $directives

--- a/src/Generator/OperationClassGenerator.php
+++ b/src/Generator/OperationClassGenerator.php
@@ -111,6 +111,14 @@ final class OperationClassGenerator extends AbstractGenerator
                     yield ') {}';
 
                     $parameters = $generator->indent(function () use ($plan, $generator) {
+                        foreach ($plan->extraParameters as $extraParameter) {
+                            yield sprintf(
+                                '%s $%s,',
+                                $this->dumpPHPType($extraParameter->type, $generator->import(...)),
+                                $extraParameter->name,
+                            );
+                        }
+
                         foreach ($plan->variables as $name => $phpType) {
                             yield sprintf(
                                 '%s $%s%s,',
@@ -138,7 +146,7 @@ final class OperationClassGenerator extends AbstractGenerator
                         }
                     });
 
-                    if ($plan->variables !== []) {
+                    if ($plan->variables !== [] || $plan->extraParameters !== []) {
                         yield 'public function execute(';
                         yield $parameters;
                         yield sprintf(
@@ -186,6 +194,10 @@ final class OperationClassGenerator extends AbstractGenerator
                             });
                             yield '],';
                             yield 'self::OPERATION_NAME,';
+
+                            foreach ($plan->extraParameters as $extraParameter) {
+                                yield sprintf('%s: $%s,', $extraParameter->name, $extraParameter->name);
+                            }
                         });
                         yield ');';
                         yield '';
@@ -226,7 +238,7 @@ final class OperationClassGenerator extends AbstractGenerator
                             yield sprintf('@throws %s', $generator->import($failedException));
                         });
 
-                        if ($plan->variables !== []) {
+                        if ($plan->variables !== [] || $plan->extraParameters !== []) {
                             yield 'public function executeOrThrow(';
                             yield $parameters;
                             yield sprintf(
@@ -244,6 +256,10 @@ final class OperationClassGenerator extends AbstractGenerator
                         yield $generator->indent(function () use ($plan, $failedException, $generator) {
                             yield '$data = $this->execute(';
                             yield $generator->indent(function () use ($plan) {
+                                foreach ($plan->extraParameters as $extraParameter) {
+                                    yield sprintf('$%s,', $extraParameter->name);
+                                }
+
                                 foreach ($plan->variables as $name => $phpType) {
                                     yield sprintf('$%s,', $name);
                                 }

--- a/src/GraphQL/OperationArgumentDirectiveSchemaExtender.php
+++ b/src/GraphQL/OperationArgumentDirectiveSchemaExtender.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\GraphQL;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\SchemaExtender;
+use InvalidArgumentException;
+use JsonException;
+use Ruudk\GraphQLCodeGenerator\Config\OperationArgument;
+
+final readonly class OperationArgumentDirectiveSchemaExtender
+{
+    /**
+     * Registers a directive (on QUERY and/or MUTATION) for every distinct `directive`
+     * referenced by the configured operation arguments that is not already defined in the
+     * schema. Directives that already exist are left untouched — they belong to the user's
+     * schema and we make no assumptions about their shape.
+     *
+     * @param list<OperationArgument> $operationArguments
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     * @throws InvariantViolation
+     * @throws Exception
+     */
+    public static function extend(Schema $schema, array $operationArguments) : Schema
+    {
+        /**
+         * @var array<string, list<string>> $locationsByDirective
+         */
+        $locationsByDirective = [];
+
+        foreach ($operationArguments as $operationArgument) {
+            if ($operationArgument->directive === null) {
+                continue;
+            }
+
+            // Leave directives that the user's schema already defines untouched.
+            if ($schema->getDirective($operationArgument->directive) !== null) {
+                continue;
+            }
+
+            // An empty operations list means the argument may target any operation type.
+            $operations = $operationArgument->operations === []
+                ? ['query', 'mutation']
+                : $operationArgument->operations;
+
+            foreach ($operations as $operation) {
+                $location = match ($operation) {
+                    'query' => 'QUERY',
+                    'mutation' => 'MUTATION',
+                };
+
+                if (in_array($location, $locationsByDirective[$operationArgument->directive] ?? [], true)) {
+                    continue;
+                }
+
+                $locationsByDirective[$operationArgument->directive][] = $location;
+            }
+        }
+
+        foreach ($locationsByDirective as $name => $locations) {
+            sort($locations);
+
+            $schema = SchemaExtender::extend(
+                $schema,
+                Parser::parse(sprintf('directive @%s on %s', $name, implode(' | ', $locations))),
+            );
+        }
+
+        return $schema;
+    }
+}

--- a/src/Planner.php
+++ b/src/Planner.php
@@ -63,6 +63,7 @@ use Ruudk\GraphQLCodeGenerator\Config\Config;
 use Ruudk\GraphQLCodeGenerator\GraphQL\AST\Printer;
 use Ruudk\GraphQLCodeGenerator\GraphQL\DocumentNodeWithSource;
 use Ruudk\GraphQLCodeGenerator\GraphQL\FragmentDefinitionNodeWithSource;
+use Ruudk\GraphQLCodeGenerator\GraphQL\OperationArgumentDirectiveSchemaExtender;
 use Ruudk\GraphQLCodeGenerator\GraphQL\PossibleTypesFinder;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\ClassConstantFinder;
 use Ruudk\GraphQLCodeGenerator\PHP\Visitor\FragmentFinder;
@@ -91,6 +92,7 @@ use Ruudk\GraphQLCodeGenerator\Validator\IndexByValidator;
 use Ruudk\GraphQLCodeGenerator\Visitor\DefinedFragmentsVisitor;
 use Ruudk\GraphQLCodeGenerator\Visitor\HookFieldRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\IndexByRemover;
+use Ruudk\GraphQLCodeGenerator\Visitor\OperationArgumentDirectiveRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\ThrowWhenNullRemover;
 use Ruudk\GraphQLCodeGenerator\Visitor\UsedFragmentsVisitor;
 use Stringable;
@@ -167,7 +169,15 @@ final class Planner
         ];
 
         $this->schemaLoader = new SchemaLoader(new Filesystem());
-        $this->schema = $this->schemaLoader->load($config->schema, $config->indexByDirective, $config->hooks !== [], $config->throwWhenNullDirective);
+        $schema = $this->schemaLoader->load($config->schema, $config->indexByDirective, $config->hooks !== [], $config->throwWhenNullDirective);
+
+        // Auto-inject the marker directives (e.g. @requiresActor) into the schema so operations
+        // using them validate. They are stripped from the operation before it is sent to the server.
+        if ($config->operationArguments !== []) {
+            $schema = OperationArgumentDirectiveSchemaExtender::extend($schema, $config->operationArguments);
+        }
+
+        $this->schema = $schema;
         $this->optimizer = new Optimizer($this->schema);
         $this->possibleTypesFinder = new PossibleTypesFinder($this->schema);
 
@@ -1006,6 +1016,21 @@ final class Planner
 
         $operationType = ucfirst($operation->operation);
 
+        $extraParameters = [];
+        foreach ($this->config->operationArguments as $operationArgument) {
+            if ($operationArgument->operations !== []
+                && ! in_array($operation->operation, $operationArgument->operations, true)) {
+                continue;
+            }
+
+            if ($operationArgument->directive !== null
+                && ! $this->directiveProcessor->hasDirective($operation->directives, $operationArgument->directive)) {
+                continue;
+            }
+
+            $extraParameters[] = $operationArgument;
+        }
+
         if ($this->config->indexByDirective) {
             $document = new IndexByRemover()->__invoke($document);
         }
@@ -1016,6 +1041,18 @@ final class Planner
 
         if ($this->config->throwWhenNullDirective) {
             $document = new ThrowWhenNullRemover()->__invoke($document);
+        }
+
+        $directiveNames = array_values(array_unique(array_filter(
+            array_map(
+                static fn($operationArgument) => $operationArgument->directive,
+                $this->config->operationArguments,
+            ),
+            static fn(?string $directive) => $directive !== null,
+        )));
+
+        if ($directiveNames !== []) {
+            $document = new OperationArgumentDirectiveRemover($directiveNames)->__invoke($document);
         }
 
         $operationDefinition = Printer::doPrint($document);
@@ -1071,6 +1108,7 @@ final class Planner
             $operationDefinition,
             $variables,
             $source,
+            $extraParameters,
         );
 
         // Create the error class plan

--- a/src/Planner/Plan/OperationClassPlan.php
+++ b/src/Planner/Plan/OperationClassPlan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ruudk\GraphQLCodeGenerator\Planner\Plan;
 
+use Ruudk\GraphQLCodeGenerator\Config\OperationArgument;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\GraphQLFileSource;
 use Ruudk\GraphQLCodeGenerator\Planner\Source\InlineSource;
 use Symfony\Component\TypeInfo\Type as SymfonyType;
@@ -12,6 +13,7 @@ final readonly class OperationClassPlan
 {
     /**
      * @param array<string, SymfonyType> $variables
+     * @param list<OperationArgument> $extraParameters
      */
     public function __construct(
         public string $path,
@@ -22,5 +24,6 @@ final readonly class OperationClassPlan
         public string $operationDefinition,
         public array $variables,
         public GraphQLFileSource | InlineSource $source,
+        public array $extraParameters = [],
     ) {}
 }

--- a/src/Visitor/OperationArgumentDirectiveRemover.php
+++ b/src/Visitor/OperationArgumentDirectiveRemover.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\Visitor;
+
+use Exception;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorRemoveNode;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+final readonly class OperationArgumentDirectiveRemover
+{
+    /**
+     * @param list<string> $directiveNames
+     */
+    public function __construct(
+        private array $directiveNames,
+    ) {}
+
+    /**
+     * @template T of Node
+     * @param T $node
+     *
+     * @throws InvalidArgumentException
+     * @throws Exception
+     * @return T
+     */
+    public function __invoke(Node $node) : Node
+    {
+        $new = Visitor::visit($node, [
+            NodeKind::DIRECTIVE => function (Node $node) : ?VisitorRemoveNode {
+                Assert::isInstanceOf($node, DirectiveNode::class);
+
+                if ( ! in_array($node->name->value, $this->directiveNames, true)) {
+                    return null;
+                }
+
+                return Visitor::removeNode();
+            },
+        ]);
+
+        Assert::isInstanceOf($new, Node::class);
+        Assert::isAOf($new, $node::class);
+
+        return $new;
+    }
+}

--- a/tests/OperationArgument/Actor.php
+++ b/tests/OperationArgument/Actor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument;
+
+final readonly class Actor
+{
+    public function __construct(
+        public string $id,
+    ) {}
+}

--- a/tests/OperationArgument/ActorTestClient.php
+++ b/tests/OperationArgument/ActorTestClient.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument;
+
+use GuzzleHttp\Psr7\Request;
+use JsonException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+/**
+ * Like the shared TestClient, but its graphql() accepts the extra `Actor` argument
+ * that the @requiresActor operation argument forwards positionally.
+ */
+final readonly class ActorTestClient
+{
+    public function __construct(
+        private ClientInterface $client,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $variables
+     *
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws JsonException
+     * @return array<mixed>
+     */
+    public function graphql(string $query, array $variables = [], ?string $operationName = null, ?Actor $actor = null) : array
+    {
+        $request = new Request(
+            'POST',
+            'https://api.github.com/graphql',
+            array_filter([
+                'Content-type' => 'application/json',
+                'X-Actor' => $actor?->id,
+            ], fn($value) => ! is_null($value)),
+            json_encode(array_filter([
+                'query' => $query,
+                'operationName' => $operationName,
+                'variables' => $variables,
+            ], fn($value) => ! is_null($value)), JSON_THROW_ON_ERROR),
+        );
+        $response = $this->client->sendRequest($request);
+        Assert::same(200, $response->getStatusCode(), 'GraphQL server responded with a %2$s status code.');
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::isArray($data, 'GraphQL server did not return an array.');
+
+        return $data;
+    }
+}

--- a/tests/OperationArgument/CreateThing.graphql
+++ b/tests/OperationArgument/CreateThing.graphql
@@ -1,0 +1,6 @@
+mutation CreateThing($name: String!) @requiresActor {
+    createThing(name: $name) {
+        id
+        name
+    }
+}

--- a/tests/OperationArgument/Generated/Mutation/CreateThing/CreateThingMutation.php
+++ b/tests/OperationArgument/Generated/Mutation/CreateThing/CreateThingMutation.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing;
+
+use Ruudk\GraphQLCodeGenerator\OperationArgument\Actor;
+use Ruudk\GraphQLCodeGenerator\OperationArgument\ActorTestClient;
+use Stringable;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class CreateThingMutation {
+    public const string OPERATION_NAME = 'CreateThing';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        mutation CreateThing($name: String!) {
+          createThing(name: $name) {
+            id
+            name
+          }
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private ActorTestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute(
+        Actor $actor,
+        Stringable|string $name,
+    ) : Data {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+                'name' => (string) $name,
+            ],
+            self::OPERATION_NAME,
+            actor: $actor,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+
+    /**
+     * @api
+     * @throws CreateThingMutationFailedException
+     */
+    public function executeOrThrow(
+        Actor $actor,
+        Stringable|string $name,
+    ) : Data {
+        $data = $this->execute(
+            $actor,
+            $name,
+        );
+
+        if ($data->errors !== []) {
+            throw new CreateThingMutationFailedException($data);
+        }
+
+        return $data;
+    }
+}

--- a/tests/OperationArgument/Generated/Mutation/CreateThing/CreateThingMutationFailedException.php
+++ b/tests/OperationArgument/Generated/Mutation/CreateThing/CreateThingMutationFailedException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing;
+
+use Exception;
+
+// This file was automatically generated and should not be edited.
+
+final class CreateThingMutationFailedException extends Exception
+{
+    public function __construct(
+        /**
+         * @api
+         */
+        public readonly Data $data,
+    ) {
+        parent::__construct(sprintf(
+            'CreateThingMutationFailedException failed%s',
+            $data->errors !== [] ? sprintf(': %s', $data->errors[0]->message) : '',
+        ));
+    }
+}

--- a/tests/OperationArgument/Generated/Mutation/CreateThing/Data.php
+++ b/tests/OperationArgument/Generated/Mutation/CreateThing/Data.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing;
+
+use Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing\Data\CreateThing;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    /**
+     * @api
+     */
+    public CreateThing $createThing {
+        get => $this->createThing ??= new CreateThing($this->data['createThing']);
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'createThing': array{
+     *         'id': string,
+     *         'name': string,
+     *         ...,
+     *     },
+     *     ...,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/OperationArgument/Generated/Mutation/CreateThing/Data/CreateThing.php
+++ b/tests/OperationArgument/Generated/Mutation/CreateThing/Data/CreateThing.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing\Data;
+
+// This file was automatically generated and should not be edited.
+
+final class CreateThing
+{
+    public string $id {
+        get => $this->id ??= $this->data['id'];
+    }
+
+    public string $name {
+        get => $this->name ??= $this->data['name'];
+    }
+
+    /**
+     * @param array{
+     *     'id': string,
+     *     'name': string,
+     *     ...,
+     * } $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {}
+}

--- a/tests/OperationArgument/Generated/Mutation/CreateThing/Error.php
+++ b/tests/OperationArgument/Generated/Mutation/CreateThing/Error.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/OperationArgument/Generated/Query/Ping/Data.php
+++ b/tests/OperationArgument/Generated/Query/Ping/Data.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\Ping;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public string $ping {
+        get => $this->ping ??= $this->data['ping'];
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'ping': string,
+     *     ...,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/OperationArgument/Generated/Query/Ping/Error.php
+++ b/tests/OperationArgument/Generated/Query/Ping/Error.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\Ping;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/OperationArgument/Generated/Query/Ping/PingQuery.php
+++ b/tests/OperationArgument/Generated/Query/Ping/PingQuery.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\Ping;
+
+use Ruudk\GraphQLCodeGenerator\OperationArgument\ActorTestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class PingQuery {
+    public const string OPERATION_NAME = 'Ping';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query Ping {
+          ping
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private ActorTestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute() : Data
+    {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+
+    /**
+     * @api
+     * @throws PingQueryFailedException
+     */
+    public function executeOrThrow() : Data
+    {
+        $data = $this->execute(
+        );
+
+        if ($data->errors !== []) {
+            throw new PingQueryFailedException($data);
+        }
+
+        return $data;
+    }
+}

--- a/tests/OperationArgument/Generated/Query/Ping/PingQueryFailedException.php
+++ b/tests/OperationArgument/Generated/Query/Ping/PingQueryFailedException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\Ping;
+
+use Exception;
+
+// This file was automatically generated and should not be edited.
+
+final class PingQueryFailedException extends Exception
+{
+    public function __construct(
+        /**
+         * @api
+         */
+        public readonly Data $data,
+    ) {
+        parent::__construct(sprintf(
+            'PingQueryFailedException failed%s',
+            $data->errors !== [] ? sprintf(': %s', $data->errors[0]->message) : '',
+        ));
+    }
+}

--- a/tests/OperationArgument/Generated/Query/PingAsActor/Data.php
+++ b/tests/OperationArgument/Generated/Query/PingAsActor/Data.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\PingAsActor;
+
+// This file was automatically generated and should not be edited.
+
+final class Data
+{
+    public string $ping {
+        get => $this->ping ??= $this->data['ping'];
+    }
+
+    /**
+     * @var list<Error>
+     */
+    public readonly array $errors;
+
+    /**
+     * @param array{
+     *     'ping': string,
+     *     ...,
+     * } $data
+     * @param list<array{
+     *     'code': string,
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * }> $errors
+     */
+    public function __construct(
+        private readonly array $data,
+        array $errors,
+    ) {
+        $this->errors = array_map(fn(array $error) => new Error($error), $errors);
+    }
+}

--- a/tests/OperationArgument/Generated/Query/PingAsActor/Error.php
+++ b/tests/OperationArgument/Generated/Query/PingAsActor/Error.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\PingAsActor;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class Error
+{
+    public string $message;
+
+    /**
+     * @param array{
+     *     'debugMessage'?: string,
+     *     'message': string,
+     *     ...,
+     * } $error
+     */
+    public function __construct(array $error)
+    {
+        $this->message = $error['debugMessage'] ?? $error['message'];
+    }
+}

--- a/tests/OperationArgument/Generated/Query/PingAsActor/PingAsActorQuery.php
+++ b/tests/OperationArgument/Generated/Query/PingAsActor/PingAsActorQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\PingAsActor;
+
+use Ruudk\GraphQLCodeGenerator\OperationArgument\Actor;
+use Ruudk\GraphQLCodeGenerator\OperationArgument\ActorTestClient;
+
+// This file was automatically generated and should not be edited.
+
+final readonly class PingAsActorQuery {
+    public const string OPERATION_NAME = 'PingAsActor';
+    public const string OPERATION_DEFINITION = <<<'GRAPHQL'
+        query PingAsActor {
+          ping
+        }
+        
+        GRAPHQL;
+
+    public function __construct(
+        private ActorTestClient $client,
+    ) {}
+
+    /**
+     * @api
+     */
+    public function execute(
+        Actor $actor,
+    ) : Data {
+        $data = $this->client->graphql(
+            self::OPERATION_DEFINITION,
+            [
+            ],
+            self::OPERATION_NAME,
+            actor: $actor,
+        );
+
+        return new Data(
+            $data['data'] ?? [], // @phpstan-ignore argument.type
+            $data['errors'] ?? [] // @phpstan-ignore argument.type
+        );
+    }
+
+    /**
+     * @api
+     * @throws PingAsActorQueryFailedException
+     */
+    public function executeOrThrow(
+        Actor $actor,
+    ) : Data {
+        $data = $this->execute(
+            $actor,
+        );
+
+        if ($data->errors !== []) {
+            throw new PingAsActorQueryFailedException($data);
+        }
+
+        return $data;
+    }
+}

--- a/tests/OperationArgument/Generated/Query/PingAsActor/PingAsActorQueryFailedException.php
+++ b/tests/OperationArgument/Generated/Query/PingAsActor/PingAsActorQueryFailedException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Query\PingAsActor;
+
+use Exception;
+
+// This file was automatically generated and should not be edited.
+
+final class PingAsActorQueryFailedException extends Exception
+{
+    public function __construct(
+        /**
+         * @api
+         */
+        public readonly Data $data,
+    ) {
+        parent::__construct(sprintf(
+            'PingAsActorQueryFailedException failed%s',
+            $data->errors !== [] ? sprintf(': %s', $data->errors[0]->message) : '',
+        ));
+    }
+}

--- a/tests/OperationArgument/OperationArgumentTest.php
+++ b/tests/OperationArgument/OperationArgumentTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ruudk\GraphQLCodeGenerator\OperationArgument;
+
+use GuzzleHttp\Psr7\Response;
+use Http\Mock\Client;
+use Override;
+use Psr\Http\Message\RequestInterface;
+use Ruudk\GraphQLCodeGenerator\Config\Config;
+use Ruudk\GraphQLCodeGenerator\GraphQLTestCase;
+use Ruudk\GraphQLCodeGenerator\OperationArgument\Generated\Mutation\CreateThing\CreateThingMutation;
+use Symfony\Component\TypeInfo\Type;
+
+final class OperationArgumentTest extends GraphQLTestCase
+{
+    #[Override]
+    public function getConfig() : Config
+    {
+        return Config::create(
+            schema: __DIR__ . '/Schema.graphql',
+            projectDir: dirname(__DIR__, 2),
+            outputDir: __DIR__ . '/Generated',
+            namespace: __NAMESPACE__ . '\\Generated',
+            client: ActorTestClient::class,
+        )
+            ->withQueriesDir(__DIR__)
+            ->enableDumpOrThrowMethods()
+            ->withOperationArgument(
+                name: 'actor',
+                type: Type::object(Actor::class),
+                directive: 'requiresActor',
+            );
+    }
+
+    public function testGenerate() : void
+    {
+        $this->assertActualMatchesExpected();
+    }
+
+    public function testExecuteForwardsActorToClient() : void
+    {
+        $mock = new Client();
+        $mock->addResponse(new Response(200, [
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'data' => [
+                'createThing' => [
+                    'id' => '1',
+                    'name' => 'Thing',
+                ],
+            ],
+        ], flags: JSON_THROW_ON_ERROR)));
+
+        $mutation = new CreateThingMutation(new ActorTestClient($mock));
+        $data = $mutation->executeOrThrow(new Actor('actor-42'), 'Thing');
+
+        self::assertSame('1', $data->createThing->id);
+        self::assertSame('Thing', $data->createThing->name);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertSame('actor-42', $request->getHeaderLine('X-Actor'));
+    }
+}

--- a/tests/OperationArgument/Ping.graphql
+++ b/tests/OperationArgument/Ping.graphql
@@ -1,0 +1,3 @@
+query Ping {
+    ping
+}

--- a/tests/OperationArgument/PingAsActor.graphql
+++ b/tests/OperationArgument/PingAsActor.graphql
@@ -1,0 +1,3 @@
+query PingAsActor @requiresActor {
+    ping
+}

--- a/tests/OperationArgument/Schema.graphql
+++ b/tests/OperationArgument/Schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+    ping: String!
+}
+
+type Mutation {
+    createThing(name: String!): Thing!
+}
+
+type Thing {
+    id: ID!
+    name: String!
+}


### PR DESCRIPTION
Some operations need to forward something to the client that is not a GraphQL variable: an actor, a tenant, a correlation or idempotency id. Until now the generated execute()/executeOrThrow() signatures were derived solely from the operation's variables, so there was no way to thread such transport-level context through the generated code.

withOperationArgument() lets you declare an extra, typed parameter that is prepended to the generated execute()/executeOrThrow() methods and forwarded to the client's graphql() call as a named argument (e.g. actor: $actor):

    Config::create(...)
        ->withOperationArgument(
            name: 'actor',
            type: Type::object(Actor::class),
            directive: 'requiresActor',
        );

Targeting is flexible:

- With a directive, the parameter is opt-in: only operations tagged with that   marker (e.g. mutation Foo @requiresActor) receive it. Without one, it applies   to every operation.
- operations restricts the argument to specific operation types; it defaults to   an empty list, meaning any type.
- Call it multiple times to inject more than one argument.

The marker directive is a code-generation concern, not part of the server's schema, so it is handled end to end: auto-registered on the schema for the configured operation types (so documents validate and KnownDirectives rejects misuse such as putting it on a field), and stripped from the operation before it is sent to the server. Running --update-schema writes these directive definitions into the schema file.

Components:

- OperationArgument value object + Config::withOperationArgument()
- OperationArgumentDirectiveSchemaExtender registers the marker directive(s)
- OperationArgumentDirectiveRemover strips them before the query is printed
- Planner resolves the applicable arguments per operation; OperationClassGenerator   prepends the parameters and forwards them as named arguments to graphql()

Covered by the tests/OperationArgument fixture (opt-in mutation, opt-in query, untouched query) plus a behavioural test asserting the actor reaches the client, and documented in the README.
